### PR TITLE
Add leverageIn method and transferLoan functionality

### DIFF
--- a/src/V4Vault.sol
+++ b/src/V4Vault.sol
@@ -72,6 +72,7 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
     event Add(uint256 indexed tokenId, address owner, uint256 oldTokenId); // when a token is added replacing another token - oldTokenId > 0
     event Remove(uint256 indexed tokenId, address owner, address recipient);
+    event Transfer(uint256 indexed tokenId, address from, address to);
 
     event ExchangeRateUpdate(uint256 debtExchangeRateX96, uint256 lendExchangeRateX96);
     // Deposit and Withdraw events are defined in IERC4626
@@ -516,6 +517,30 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         transformApprovals[msg.sender][tokenId][target] = isActive;
 
         emit ApprovedTransform(tokenId, msg.sender, target, isActive);
+    }
+
+    /// @notice Transfers ownership of a loan to a new owner
+    /// @param tokenId The token ID of the loan to transfer
+    /// @param newOwner The address of the new owner
+    function transferLoan(uint256 tokenId, address newOwner) external override {
+
+        // transferLoan is not allowed during transformer mode
+        if (transformedTokenId != 0) {
+            revert TransformNotAllowed();
+        }
+
+        address currentOwner = tokenOwner[tokenId];
+        if (currentOwner != msg.sender) {
+            revert Unauthorized();
+        }
+        if (newOwner == address(0)) {
+            revert Unauthorized();
+        }
+
+        _removeTokenFromOwner(currentOwner, tokenId);
+        _addTokenToOwner(newOwner, tokenId);
+
+        emit Transfer(tokenId, currentOwner, newOwner);
     }
 
     /// @notice Method which allows a contract to transform a loan by changing it (and only at the end checking collateral)

--- a/src/interfaces/IVault.sol
+++ b/src/interfaces/IVault.sol
@@ -41,6 +41,7 @@ interface IVault is IERC4626 {
 
     function create(uint256 tokenId, address recipient) external;
 
+    function transferLoan(uint256 tokenId, address newOwner) external;
 
     function approveTransform(uint256 tokenId, address target, bool active) external;
     function transform(uint256 tokenId, address transformer, bytes calldata data) external returns (uint256);

--- a/src/transformers/LeverageTransformer.sol
+++ b/src/transformers/LeverageTransformer.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.0;
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 import {IPositionManager} from "@uniswap/v4-periphery/src/interfaces/IPositionManager.sol";
 import {IPermit2} from "@uniswap/v4-periphery/lib/permit2/src/interfaces/IPermit2.sol";
@@ -10,9 +12,10 @@ import {LiquidityAmounts} from "@uniswap/v4-periphery/src/libraries/LiquidityAmo
 import {PositionInfo} from "@uniswap/v4-periphery/src/libraries/PositionInfoLibrary.sol";
 
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
-import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 
@@ -22,7 +25,7 @@ import {Transformer, Ownable} from "./Transformer.sol";
 
 /// @title LeverageTransformer
 /// @notice Functionality to leverage / deleverage positions direcly in one tx
-contract LeverageTransformer is Transformer, Swapper {
+contract LeverageTransformer is Transformer, Swapper, IERC721Receiver {
 
     /// @notice Permit2 contract
     IPermit2 public immutable permit2;
@@ -237,5 +240,434 @@ contract LeverageTransformer is Transformer, Swapper {
         if (amount1 != 0 && !(token == token1)) {
             token1.transfer(params.recipient, amount1);
         }
+    }
+
+    struct LeverageInParams {
+        // vault to create position in
+        address vault;
+        // pool key parameters (one of token0/token1 must be the vault's lend token)
+        Currency token0;
+        Currency token1;
+        uint24 fee;
+        int24 tickSpacing;
+        address hook;
+        // position ticks for the leveraged position
+        int24 tickLower;
+        int24 tickUpper;
+        // initial token amount provided by user (must be the non-lend token)
+        uint256 initialAmount;
+        // how much to borrow
+        uint256 borrowAmount;
+        // how much to swap from lend token to other token (or vice versa if swapDirection is false)
+        uint256 amountIn;
+        uint256 amountOutMin;
+        bytes swapData;
+        // true = swap lend token to other token, false = swap other token to lend token
+        bool swapDirection;
+        // for adding liquidity slippage
+        uint256 amountAddMin0;
+        uint256 amountAddMin1;
+        // recipient for leftover tokens
+        address recipient;
+        // for all uniswap deadlineable functions
+        uint256 deadline;
+        // hook data for minting the dummy position (optional)
+        bytes mintHookData;
+        // hook data for the final leveraged position (optional)
+        bytes mintFinalHookData;
+        // hook data for decreasing liquidity from dummy position (optional)
+        bytes decreaseLiquidityHookData;
+    }
+
+    struct LeverageInTransformParams {
+        // which token is being transformed (dummy position)
+        uint256 tokenId;
+        // pool key parameters for the new position (one of token0/token1 must be the vault's lend token)
+        Currency token0;
+        Currency token1;
+        uint24 fee;
+        int24 tickSpacing;
+        address hook;
+        // position ticks for the final leveraged position
+        int24 tickLower;
+        int24 tickUpper;
+        // how much to borrow
+        uint256 borrowAmount;
+        // how much to swap from lend token to other token (or vice versa if swapDirection is false)
+        uint256 amountIn;
+        uint256 amountOutMin;
+        bytes swapData;
+        // true = swap lend token to other token, false = swap other token to lend token
+        bool swapDirection;
+        // for adding liquidity slippage
+        uint256 amountAddMin0;
+        uint256 amountAddMin1;
+        // recipient for leftover tokens
+        address recipient;
+        // for all uniswap deadlineable functions
+        uint256 deadline;
+        // hook data for the final leveraged position (optional)
+        bytes mintHookData;
+        // hook data for decreasing liquidity from dummy position (optional)
+        bytes decreaseLiquidityHookData;
+    }
+
+    /// @notice Creates a leveraged position from a single token
+    /// @dev Creates a one-sided dummy position, adds it to vault as collateral, then transforms it to the desired position
+    /// @param params The parameters for creating the leveraged position
+    /// @return tokenId The token ID of the final leveraged position
+    function leverageIn(LeverageInParams calldata params) external payable returns (uint256 tokenId) {
+        if (!vaults[params.vault]) {
+            revert Unauthorized();
+        }
+
+        // Validate that one token is the lend token
+        Currency lendToken = Currency.wrap(IVault(params.vault).asset());
+        Currency otherToken;
+        if (lendToken == params.token0) {
+            otherToken = params.token1;
+        } else if (lendToken == params.token1) {
+            otherToken = params.token0;
+        } else {
+            revert InvalidToken();
+        }
+
+        // Transfer initial token from user and create dummy position
+        tokenId = _createDummyPosition(params, otherToken);
+
+        // Send the dummy position to the vault (creates a loan with 0 debt)
+        // The owner is set to this contract (LeverageTransformer) so we can call transform directly
+        IERC721(address(positionManager)).safeTransferFrom(address(this), params.vault, tokenId);
+
+        // Call transform on the vault to create the final leveraged position
+        tokenId = _callTransform(params, tokenId);
+
+        // Transfer ownership of the loan to the original caller
+        IVault(params.vault).transferLoan(tokenId, params.recipient);
+    }
+
+    /// @dev Helper function to create the dummy position
+    function _createDummyPosition(LeverageInParams calldata params, Currency otherToken) internal returns (uint256 tokenId) {
+        // Transfer initial token from user (must be the non-lend token)
+        if (!otherToken.isAddressZero()) {
+            SafeERC20.safeTransferFrom(
+                IERC20(Currency.unwrap(otherToken)),
+                msg.sender,
+                address(this),
+                params.initialAmount
+            );
+        }
+
+        // Create pool key
+        PoolKey memory poolKey = PoolKey({
+            currency0: params.token0,
+            currency1: params.token1,
+            fee: params.fee,
+            tickSpacing: params.tickSpacing,
+            hooks: IHooks(params.hook)
+        });
+
+        // Get dummy tick range based on which token is the other token
+        (int24 dummyTickLower, int24 dummyTickUpper) = _getDummyTickRange(poolKey, otherToken, params.tickSpacing);
+
+        // Handle approval for the initial token
+        _handleApproval(permit2, otherToken, params.initialAmount);
+
+        // Calculate liquidity for dummy position
+        uint256 amount0 = otherToken == params.token0 ? params.initialAmount : 0;
+        uint256 amount1 = otherToken == params.token1 ? params.initialAmount : 0;
+
+        uint128 liquidity = _calculateLiquidity(dummyTickLower, dummyTickUpper, poolKey, amount0, amount1);
+
+        // Mint the dummy position
+        _mintDummyPosition(poolKey, dummyTickLower, dummyTickUpper, liquidity, params);
+
+        // Get the newly minted token ID
+        tokenId = positionManager.nextTokenId() - 1;
+
+        // Return any leftover tokens to the caller (may occur due to rounding)
+        uint256 leftover = otherToken.balanceOfSelf();
+        if (leftover > 0) {
+            otherToken.transfer(msg.sender, leftover);
+        }
+    }
+
+    /// @dev Helper function to get dummy tick range for one-sided position
+    /// @dev Uses a wide tick range to ensure all initial tokens can be deposited
+    function _getDummyTickRange(
+        PoolKey memory poolKey,
+        Currency otherToken,
+        int24 tickSpacing
+    ) internal view returns (int24 dummyTickLower, int24 dummyTickUpper) {
+        // Get current tick to create a one-sided position
+        (, int24 currentTick,,) = StateLibrary.getSlot0(poolManager, PoolIdLibrary.toId(poolKey));
+
+        // Round current tick to tick spacing
+        int24 roundedTick = (currentTick / tickSpacing) * tickSpacing;
+
+        // Use MIN_TICK and MAX_TICK aligned to tick spacing to create a wide range
+        // This ensures all tokens can be deposited into the dummy position
+        int24 minTick = (TickMath.MIN_TICK / tickSpacing) * tickSpacing;
+        int24 maxTick = (TickMath.MAX_TICK / tickSpacing) * tickSpacing;
+
+        if (otherToken == poolKey.currency0) {
+            // Token0 only position: must be above current price
+            // Use range from just above current tick to max tick
+            dummyTickLower = roundedTick + tickSpacing;
+            dummyTickUpper = maxTick;
+        } else {
+            // Token1 only position: must be below current price
+            // Use range from min tick to just below current tick
+            dummyTickLower = minTick;
+            dummyTickUpper = roundedTick - tickSpacing;
+        }
+    }
+
+    /// @dev Helper function to mint the dummy position
+    function _mintDummyPosition(
+        PoolKey memory poolKey,
+        int24 tickLower,
+        int24 tickUpper,
+        uint128 liquidity,
+        LeverageInParams calldata params
+    ) internal {
+        (bytes memory actions, bytes[] memory mintParams) = _buildActionsForIncreasingLiquidity(
+            uint8(Actions.MINT_POSITION),
+            poolKey.currency0,
+            poolKey.currency1
+        );
+
+        mintParams[0] = abi.encode(
+            poolKey,
+            tickLower,
+            tickUpper,
+            liquidity,
+            type(uint128).max,
+            type(uint128).max,
+            address(this),
+            params.mintHookData
+        );
+
+        positionManager.modifyLiquidities{value: address(this).balance}(
+            abi.encode(actions, mintParams),
+            params.deadline
+        );
+    }
+
+    /// @dev Helper function to call transform on vault
+    function _callTransform(LeverageInParams calldata params, uint256 tokenId) internal returns (uint256) {
+        // Build transform params for the leverageInTransform method
+        LeverageInTransformParams memory transformParams = LeverageInTransformParams({
+            tokenId: tokenId,
+            token0: params.token0,
+            token1: params.token1,
+            fee: params.fee,
+            tickSpacing: params.tickSpacing,
+            hook: params.hook,
+            tickLower: params.tickLower,
+            tickUpper: params.tickUpper,
+            borrowAmount: params.borrowAmount,
+            amountIn: params.amountIn,
+            amountOutMin: params.amountOutMin,
+            swapData: params.swapData,
+            swapDirection: params.swapDirection,
+            amountAddMin0: params.amountAddMin0,
+            amountAddMin1: params.amountAddMin1,
+            recipient: params.recipient,
+            deadline: params.deadline,
+            mintHookData: params.mintFinalHookData,
+            decreaseLiquidityHookData: params.decreaseLiquidityHookData
+        });
+
+        // Call transform on the vault to create the final leveraged position
+        bytes memory transformData = abi.encodeWithSelector(
+            this.leverageInTransform.selector,
+            transformParams
+        );
+
+        return IVault(params.vault).transform(tokenId, address(this), transformData);
+    }
+
+    /// @notice Transform method called from vault to create the final leveraged position
+    /// @dev Removes dummy position liquidity, borrows, swaps, and mints new position with desired ticks
+    /// @param params The parameters for the transform
+    function leverageInTransform(LeverageInTransformParams calldata params) external {
+        _validateCaller(positionManager, params.tokenId);
+
+        Currency lendToken = Currency.wrap(IVault(msg.sender).asset());
+
+        // Remove dummy position, borrow and swap - returns amounts available for new position
+        (uint256 amount0, uint256 amount1) = _removeBorrowAndSwap(params, lendToken);
+
+        // Create the new position with desired ticks
+        uint256 newTokenId = _mintNewPosition(params, amount0, amount1);
+
+        // Verify slippage and send new position to vault
+        _finalizeLeverageIn(params, amount0, amount1, newTokenId);
+    }
+
+    /// @dev Helper function to remove dummy position, borrow, and swap
+    function _removeBorrowAndSwap(
+        LeverageInTransformParams calldata params,
+        Currency lendToken
+    ) internal returns (uint256 amount0, uint256 amount1) {
+        // Determine which token is the other (non-lend) token
+        Currency otherToken = lendToken == params.token0 ? params.token1 : params.token0;
+
+        // Get current liquidity of the dummy position
+        uint128 dummyLiquidity = positionManager.getPositionLiquidity(params.tokenId);
+
+        // Remove all liquidity from the dummy position (and collect any fees)
+        _decreaseLiquidity(
+            params.tokenId,
+            dummyLiquidity,
+            0,
+            0,
+            params.deadline,
+            params.decreaseLiquidityHookData
+        );
+
+        // Get the current token balances which include:
+        // - Leftover tokens from the initial deposit that weren't used by the dummy position
+        // - Tokens returned from decreasing the dummy position liquidity
+        amount0 = params.token0.balanceOfSelf();
+        amount1 = params.token1.balanceOfSelf();
+
+        // Borrow from the vault
+        IVault(msg.sender).borrow(params.tokenId, params.borrowAmount);
+
+        // Add borrowed amount to the lend token balance
+        if (lendToken == params.token0) {
+            amount0 += params.borrowAmount;
+        } else {
+            amount1 += params.borrowAmount;
+        }
+
+        // Perform optional swap if needed
+        if (params.amountIn != 0) {
+            Currency tokenIn;
+            Currency tokenOut;
+
+            if (params.swapDirection) {
+                // Swap lend token to other token
+                tokenIn = lendToken;
+                tokenOut = otherToken;
+            } else {
+                // Swap other token to lend token
+                tokenIn = otherToken;
+                tokenOut = lendToken;
+            }
+
+            (uint256 amountIn, uint256 amountOut) = _routerSwap(
+                Swapper.RouterSwapParams(tokenIn, tokenOut, params.amountIn, params.amountOutMin, params.swapData)
+            );
+
+            // Update amounts based on which tokens were swapped
+            if (tokenIn == params.token0) {
+                amount0 -= amountIn;
+            } else {
+                amount1 -= amountIn;
+            }
+            if (tokenOut == params.token0) {
+                amount0 += amountOut;
+            } else {
+                amount1 += amountOut;
+            }
+        }
+    }
+
+    /// @dev Helper function to mint the new position
+    function _mintNewPosition(
+        LeverageInTransformParams calldata params,
+        uint256 amount0,
+        uint256 amount1
+    ) internal returns (uint256 newTokenId) {
+        // Approve tokens for position manager
+        _handleApproval(permit2, params.token0, amount0);
+        _handleApproval(permit2, params.token1, amount1);
+
+        // Create pool key for the new position
+        PoolKey memory poolKey = PoolKey({
+            currency0: params.token0,
+            currency1: params.token1,
+            fee: params.fee,
+            tickSpacing: params.tickSpacing,
+            hooks: IHooks(params.hook)
+        });
+
+        // Calculate liquidity for the new position
+        uint128 newLiquidity = _calculateLiquidity(params.tickLower, params.tickUpper, poolKey, amount0, amount1);
+
+        // Mint the new position with desired ticks
+        (bytes memory actions, bytes[] memory mintParams) = _buildActionsForIncreasingLiquidity(
+            uint8(Actions.MINT_POSITION),
+            params.token0,
+            params.token1
+        );
+
+        mintParams[0] = abi.encode(
+            poolKey,
+            params.tickLower,
+            params.tickUpper,
+            newLiquidity,
+            type(uint128).max,
+            type(uint128).max,
+            address(this),
+            params.mintHookData
+        );
+
+        positionManager.modifyLiquidities{value: address(this).balance}(
+            abi.encode(actions, mintParams),
+            params.deadline
+        );
+
+        // Get the newly minted token ID
+        newTokenId = positionManager.nextTokenId() - 1;
+    }
+
+    /// @dev Helper function to finalize the leverage in operation
+    function _finalizeLeverageIn(
+        LeverageInTransformParams calldata params,
+        uint256 amount0,
+        uint256 amount1,
+        uint256 newTokenId
+    ) internal {
+        // Calculate amounts added
+        uint256 added0 = amount0 - params.token0.balanceOfSelf();
+        uint256 added1 = amount1 - params.token1.balanceOfSelf();
+
+        // Check minimum amounts were added
+        if (added0 < params.amountAddMin0) {
+            revert InsufficientAmountAdded();
+        }
+        if (added1 < params.amountAddMin1) {
+            revert InsufficientAmountAdded();
+        }
+
+        // Send the new position to the vault - this will replace the dummy position
+        // The vault's onERC721Received will handle replacing the old position with the new one
+        IERC721(address(positionManager)).safeTransferFrom(address(this), msg.sender, newTokenId);
+
+        // Send leftover tokens to recipient (lendToken is always one of token0 or token1)
+        uint256 leftover0 = params.token0.balanceOfSelf();
+        uint256 leftover1 = params.token1.balanceOfSelf();
+
+        if (leftover0 != 0) {
+            params.token0.transfer(params.recipient, leftover0);
+        }
+        if (leftover1 != 0) {
+            params.token1.transfer(params.recipient, leftover1);
+        }
+    }
+
+    /// @notice Callback for receiving ERC721 tokens
+    /// @dev Required for receiving NFTs from the position manager
+    function onERC721Received(address, address, uint256, bytes calldata)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        return IERC721Receiver.onERC721Received.selector;
     }
 }

--- a/test/integration/V4Vault.t.sol
+++ b/test/integration/V4Vault.t.sol
@@ -1461,5 +1461,409 @@ contract V4VaultTest is V4ForkTestBase {
         vm.stopPrank();
     }
 
+    // leverage in tests
+    function test_LeverageIn() public {
+        LeverageTransformer leverageTransformer = new LeverageTransformer(positionManager, address(swapRouter), EX0x, permit2);
+        vault.setTransformer(address(leverageTransformer), true);
+        leverageTransformer.setVault(address(vault));
+
+        // Deposit USDC to the vault so there's liquidity to borrow
+        _deposit(100000000, WHALE_ACCOUNT); // 100 USDC
+
+        // Get pool info from existing position to reuse pool key parameters
+        (PoolKey memory poolKey, ) = positionManager.getPoolAndPositionInfo(nft1TokenId);
+
+        // User starts with WETH and wants to create a leveraged position
+        address user = address(0x1234567890123456789012345678901234567890);
+        uint256 initialWethAmount = 0.01 ether;
+
+        // Give user some WETH
+        deal(address(weth), user, initialWethAmount);
+
+        console.log("=== LEVERAGE IN TEST ===");
+        console.log("Pool token0:", Currency.unwrap(poolKey.currency0));
+        console.log("Pool token1:", Currency.unwrap(poolKey.currency1));
+        console.log("Pool fee:", poolKey.fee);
+        console.log("Pool tickSpacing:", poolKey.tickSpacing);
+        console.log("User initial WETH:", initialWethAmount);
+
+        vm.startPrank(user);
+
+        // Approve WETH for the leverage transformer
+        weth.approve(address(leverageTransformer), initialWethAmount);
+
+        // Use reasonable tick ranges (not the full range from existing position)
+        // For USDC/WETH pool with tickSpacing=10, use a range around current price
+        int24 tickLower = -200000; // reasonable lower bound
+        int24 tickUpper = -190000; // reasonable upper bound
+
+        // Create swap data to swap some borrowed USDC to WETH
+        uint256 borrowAmount = 10000000; // 10 USDC
+        uint256 swapAmount = 5000000; // 5 USDC to swap to WETH
+        bytes memory swapData = _createSwapData(swapAmount, 1, address(usdc), address(weth), address(leverageTransformer));
+
+        LeverageTransformer.LeverageInParams memory params = LeverageTransformer.LeverageInParams({
+            vault: address(vault),
+            token0: poolKey.currency0,
+            token1: poolKey.currency1,
+            fee: poolKey.fee,
+            tickSpacing: poolKey.tickSpacing,
+            hook: address(poolKey.hooks),
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            initialAmount: initialWethAmount,
+            borrowAmount: borrowAmount,
+            amountIn: swapAmount,
+            amountOutMin: 1,
+            swapData: swapData,
+            swapDirection: true, // swap USDC (lend token) to WETH (other token)
+            amountAddMin0: 0,
+            amountAddMin1: 0,
+            recipient: user,
+            deadline: block.timestamp,
+            mintHookData: "",
+            mintFinalHookData: "",
+            decreaseLiquidityHookData: ""
+        });
+
+        // Execute leverage in
+        uint256 newTokenId = leverageTransformer.leverageIn(params);
+
+        console.log("New token ID:", newTokenId);
+
+        // Verify the position was created and is owned by the vault
+        assertEq(IERC721(address(positionManager)).ownerOf(newTokenId), address(vault), "Position should be owned by vault");
+
+        // Verify the loan owner is the user
+        assertEq(vault.ownerOf(newTokenId), user, "Loan should be owned by user");
+
+        // Verify the loan has debt
+        uint256 debtShares = vault.loans(newTokenId);
+        assertGt(debtShares, 0, "Loan should have debt shares");
+
+        (uint256 debt, uint256 fullValue, uint256 collateralValue,,) = vault.loanInfo(newTokenId);
+        console.log("Debt:", debt);
+        console.log("Full value:", fullValue);
+        console.log("Collateral value:", collateralValue);
+
+        assertGt(debt, 0, "Loan should have debt");
+        assertGt(collateralValue, debt, "Loan should be healthy (collateral > debt)");
+
+        // Verify the new position has liquidity
+        uint128 liquidity = positionManager.getPositionLiquidity(newTokenId);
+        assertGt(liquidity, 0, "Position should have liquidity");
+        console.log("Position liquidity:", liquidity);
+
+        vm.stopPrank();
+    }
+
+    // Test leverageIn with pool where token0 is the lend token (USDC)
+    function test_LeverageIn_Token0IsLendToken() public {
+        LeverageTransformer leverageTransformer = new LeverageTransformer(positionManager, address(swapRouter), EX0x, permit2);
+        vault.setTransformer(address(leverageTransformer), true);
+        leverageTransformer.setVault(address(vault));
+
+        // Deposit USDC to the vault so there's liquidity to borrow
+        _deposit(100000000, WHALE_ACCOUNT); // 100 USDC
+
+        // Get pool info from existing position
+        (PoolKey memory poolKey, ) = positionManager.getPoolAndPositionInfo(nft1TokenId);
+
+        // Verify USDC is token0 in this pool
+        assertEq(Currency.unwrap(poolKey.currency0), address(usdc), "USDC should be token0");
+
+        // User starts with WETH (token1) and wants to create a leveraged position
+        address user = address(0x1234567890123456789012345678901234567890);
+        uint256 initialWethAmount = 0.01 ether;
+
+        // Give user some WETH
+        deal(address(weth), user, initialWethAmount);
+
+        console.log("=== LEVERAGE IN TEST (Token0 is lend token) ===");
+
+        vm.startPrank(user);
+        weth.approve(address(leverageTransformer), initialWethAmount);
+
+        // Use reasonable tick ranges
+        int24 tickLower = -200000;
+        int24 tickUpper = -190000;
+
+        uint256 borrowAmount = 10000000; // 10 USDC
+        uint256 swapAmount = 5000000; // 5 USDC to swap to WETH
+        bytes memory swapData = _createSwapData(swapAmount, 1, address(usdc), address(weth), address(leverageTransformer));
+
+        LeverageTransformer.LeverageInParams memory params = LeverageTransformer.LeverageInParams({
+            vault: address(vault),
+            token0: poolKey.currency0,
+            token1: poolKey.currency1,
+            fee: poolKey.fee,
+            tickSpacing: poolKey.tickSpacing,
+            hook: address(poolKey.hooks),
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            initialAmount: initialWethAmount,
+            borrowAmount: borrowAmount,
+            amountIn: swapAmount,
+            amountOutMin: 1,
+            swapData: swapData,
+            swapDirection: true, // swap lend token (USDC) to other token (WETH)
+            amountAddMin0: 0,
+            amountAddMin1: 0,
+            recipient: user,
+            deadline: block.timestamp,
+            mintHookData: "",
+            mintFinalHookData: "",
+            decreaseLiquidityHookData: ""
+        });
+
+        uint256 newTokenId = leverageTransformer.leverageIn(params);
+
+        // Verify position and loan
+        assertEq(IERC721(address(positionManager)).ownerOf(newTokenId), address(vault), "Position should be owned by vault");
+        assertEq(vault.ownerOf(newTokenId), user, "Loan should be owned by user");
+
+        (uint256 debt,, uint256 collateralValue,,) = vault.loanInfo(newTokenId);
+        assertGt(collateralValue, debt, "Loan should be healthy");
+
+        vm.stopPrank();
+    }
+
+    // Test that leverageIn reverts when neither token is the lend token
+    function test_LeverageIn_InvalidToken() public {
+        LeverageTransformer leverageTransformer = new LeverageTransformer(positionManager, address(swapRouter), EX0x, permit2);
+        vault.setTransformer(address(leverageTransformer), true);
+        leverageTransformer.setVault(address(vault));
+
+        address user = address(0x1234567890123456789012345678901234567890);
+
+        vm.startPrank(user);
+
+        // Try to create position with DAI/WETH pool (neither is USDC which is the lend token)
+        LeverageTransformer.LeverageInParams memory params = LeverageTransformer.LeverageInParams({
+            vault: address(vault),
+            token0: Currency.wrap(address(dai)),
+            token1: Currency.wrap(address(weth)),
+            fee: 3000,
+            tickSpacing: 60,
+            hook: address(0),
+            tickLower: -887220,
+            tickUpper: 887220,
+            initialAmount: 1 ether,
+            borrowAmount: 10000000,
+            amountIn: 0,
+            amountOutMin: 0,
+            swapData: "",
+            swapDirection: true,
+            amountAddMin0: 0,
+            amountAddMin1: 0,
+            recipient: user,
+            deadline: block.timestamp,
+            mintHookData: "",
+            mintFinalHookData: "",
+            decreaseLiquidityHookData: ""
+        });
+
+        vm.expectRevert(Constants.InvalidToken.selector);
+        leverageTransformer.leverageIn(params);
+
+        vm.stopPrank();
+    }
+
+    // Test leverageIn with full range position
+    function test_LeverageIn_FullRange() public {
+        LeverageTransformer leverageTransformer = new LeverageTransformer(positionManager, address(swapRouter), EX0x, permit2);
+        vault.setTransformer(address(leverageTransformer), true);
+        leverageTransformer.setVault(address(vault));
+
+        // Increase limits for this test (need ~5000 USDC)
+        vault.setLimits(0, 10000000000, 10000000000, 10000000000, 10000000000); // 10000 USDC limits
+
+        // Deposit USDC to the vault so there's liquidity to borrow
+        // For full range with 1 ETH (~$4318), we need ~$4318 USDC to balance
+        _deposit(5000000000, WHALE_ACCOUNT); // 5000 USDC
+
+        // Get pool info from existing position to reuse pool key parameters
+        (PoolKey memory poolKey, ) = positionManager.getPoolAndPositionInfo(nft1TokenId);
+
+        // User starts with WETH and wants to create a full range leveraged position
+        address user = address(0x1234567890123456789012345678901234567890);
+        uint256 initialWethAmount = 1 ether; // ~$4318 at current prices
+
+        // Give user some WETH
+        deal(address(weth), user, initialWethAmount);
+
+        console.log("=== LEVERAGE IN FULL RANGE TEST ===");
+        console.log("Pool token0:", Currency.unwrap(poolKey.currency0));
+        console.log("Pool token1:", Currency.unwrap(poolKey.currency1));
+        console.log("Pool fee:", poolKey.fee);
+        console.log("Pool tickSpacing:", poolKey.tickSpacing);
+        console.log("User initial WETH:", initialWethAmount);
+
+        vm.startPrank(user);
+
+        // Approve WETH for the leverage transformer
+        weth.approve(address(leverageTransformer), initialWethAmount);
+
+        // Use full range tick values (aligned to tick spacing)
+        // TickMath.MIN_TICK = -887272, TickMath.MAX_TICK = 887272
+        // For tickSpacing = 10, we need to round to nearest multiple of 10
+        int24 tickLower = -887270; // -887272 rounded up to multiple of 10
+        int24 tickUpper = 887270;  // 887272 rounded down to multiple of 10
+
+        // For full range positions, borrow USDC equivalent in value to the initial WETH (~$4318)
+        // No swapping needed - both tokens go directly into the position
+        uint256 borrowAmount = 4300000000; // 4300 USDC (~$4318 worth)
+
+        LeverageTransformer.LeverageInParams memory params = LeverageTransformer.LeverageInParams({
+            vault: address(vault),
+            token0: poolKey.currency0,
+            token1: poolKey.currency1,
+            fee: poolKey.fee,
+            tickSpacing: poolKey.tickSpacing,
+            hook: address(poolKey.hooks),
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            initialAmount: initialWethAmount,
+            borrowAmount: borrowAmount,
+            amountIn: 0, // no swap
+            amountOutMin: 0,
+            swapData: bytes(""),
+            swapDirection: true,
+            amountAddMin0: 0,
+            amountAddMin1: 0,
+            recipient: user,
+            deadline: block.timestamp,
+            mintHookData: "",
+            mintFinalHookData: "",
+            decreaseLiquidityHookData: ""
+        });
+
+        // Execute leverage in
+        uint256 newTokenId = leverageTransformer.leverageIn(params);
+
+        console.log("New token ID:", newTokenId);
+
+        // Verify the position was created and is owned by the vault
+        assertEq(IERC721(address(positionManager)).ownerOf(newTokenId), address(vault), "Position should be owned by vault");
+
+        // Verify the loan owner is the user
+        assertEq(vault.ownerOf(newTokenId), user, "Loan should be owned by user");
+
+        // Verify the loan has debt
+        uint256 debtShares = vault.loans(newTokenId);
+        assertGt(debtShares, 0, "Loan should have debt shares");
+
+        (uint256 debt, uint256 fullValue, uint256 collateralValue,,) = vault.loanInfo(newTokenId);
+        console.log("Debt:", debt);
+        console.log("Full value:", fullValue);
+        console.log("Collateral value:", collateralValue);
+
+        assertGt(debt, 0, "Loan should have debt");
+        assertGt(collateralValue, debt, "Loan should be healthy (collateral > debt)");
+
+        // Verify the new position has liquidity
+        uint128 liquidity = positionManager.getPositionLiquidity(newTokenId);
+        assertGt(liquidity, 0, "Position should have liquidity");
+        console.log("Position liquidity:", liquidity);
+
+        // Verify position tick range is full range
+        (, PositionInfo positionInfo) = positionManager.getPoolAndPositionInfo(newTokenId);
+        assertEq(positionInfo.tickLower(), tickLower, "Position should have full range tickLower");
+        assertEq(positionInfo.tickUpper(), tickUpper, "Position should have full range tickUpper");
+        console.log("Position tickLower:", positionInfo.tickLower());
+        console.log("Position tickUpper:", positionInfo.tickUpper());
+
+        vm.stopPrank();
+    }
+
+    // ============ transferLoan Tests ============
+
+    function test_TransferLoan() public {
+        _setupBasicLoan(true);
+
+        address newOwner = address(0x9999);
+
+        // Verify initial owner
+        assertEq(vault.ownerOf(nft1TokenId), nft1Owner, "Initial owner should be nft1Owner");
+
+        // Transfer the loan
+        vm.prank(nft1Owner);
+        vault.transferLoan(nft1TokenId, newOwner);
+
+        // Verify new owner
+        assertEq(vault.ownerOf(nft1TokenId), newOwner, "New owner should be set");
+
+        // Verify old owner no longer owns it
+        assertEq(vault.loanCount(nft1Owner), 0, "Old owner should have no tokens");
+
+        // Verify new owner has the token
+        assertEq(vault.loanCount(newOwner), 1, "New owner should have one token");
+        assertEq(vault.loanAtIndex(newOwner, 0), nft1TokenId, "New owner should have the transferred token");
+    }
+
+    function test_TransferLoan_Unauthorized() public {
+        _setupBasicLoan(true);
+
+        address notOwner = address(0x8888);
+        address newOwner = address(0x9999);
+
+        // Try to transfer from non-owner - should fail
+        vm.prank(notOwner);
+        vm.expectRevert(Constants.Unauthorized.selector);
+        vault.transferLoan(nft1TokenId, newOwner);
+    }
+
+    function test_TransferLoan_ToZeroAddress() public {
+        _setupBasicLoan(true);
+
+        // Try to transfer to zero address - should fail
+        vm.prank(nft1Owner);
+        vm.expectRevert(Constants.Unauthorized.selector);
+        vault.transferLoan(nft1TokenId, address(0));
+    }
+
+    function test_TransferLoan_PreservesDebt() public {
+        _setupBasicLoan(true);
+
+        address newOwner = address(0x9999);
+
+        // Get debt before transfer
+        (uint256 debtBefore,,,,) = vault.loanInfo(nft1TokenId);
+        assertGt(debtBefore, 0, "Should have debt before transfer");
+
+        // Transfer the loan
+        vm.prank(nft1Owner);
+        vault.transferLoan(nft1TokenId, newOwner);
+
+        // Verify debt is preserved
+        (uint256 debtAfter,,,,) = vault.loanInfo(nft1TokenId);
+        assertEq(debtAfter, debtBefore, "Debt should be preserved after transfer");
+    }
+
+    function test_TransferLoan_NewOwnerCanRepay() public {
+        _setupBasicLoan(true);
+
+        address newOwner = address(0x9999);
+
+        // Transfer the loan
+        vm.prank(nft1Owner);
+        vault.transferLoan(nft1TokenId, newOwner);
+
+        // Give new owner some USDC to repay
+        deal(address(usdc), newOwner, 200000000); // 200 USDC
+
+        // Get debt amount
+        (uint256 debt,,,,) = vault.loanInfo(nft1TokenId);
+
+        // New owner repays the debt
+        vm.startPrank(newOwner);
+        usdc.approve(address(vault), debt);
+        vault.repay(nft1TokenId, debt, false);
+        vm.stopPrank();
+
+        // Verify debt is repaid
+        (uint256 debtAfter,,,,) = vault.loanInfo(nft1TokenId);
+        assertEq(debtAfter, 0, "Debt should be zero after repayment");
+    }
 
 }


### PR DESCRIPTION
## Summary

- Implement `leverageIn` method to create leveraged positions from a single initial token
- Add `transferLoan` function allowing borrowers to transfer loan ownership
- Ensure all initial tokens are utilized by creating wide-range dummy positions
- Return leftover tokens from dummy position creation to the caller

## Test Plan

- ✅ test_LeverageIn - Basic leverageIn functionality
- ✅ test_LeverageIn_Token0IsLendToken - Handles when USDC (lend token) is token0
- ✅ test_LeverageIn_InvalidToken - Verifies revert when neither token is lend token
- ✅ test_LeverageIn_FullRange - Creates full range (MIN_TICK to MAX_TICK) positions
- ✅ test_TransferLoan - Basic loan ownership transfer
- ✅ test_TransferLoan_Unauthorized - Non-owner cannot transfer
- ✅ test_TransferLoan_ToZeroAddress - Cannot transfer to zero address
- ✅ test_TransferLoan_PreservesDebt - Debt is preserved after transfer
- ✅ test_TransferLoan_NewOwnerCanRepay - New owner can repay inherited debt

🤖 Generated with [Claude Code](https://claude.com/claude-code)