### PR TITLE
Add Unichain deployment script and V4Oracle price calculation tests

### DIFF
--- a/script/DeployUnichain.s.sol
+++ b/script/DeployUnichain.s.sol
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Script, console} from "forge-std/Script.sol";
+
+// import {V4Utils} from "../src/transformers/V4Utils.sol";
+import {V4Oracle, AggregatorV3Interface} from "../src/V4Oracle.sol";
+// import {V4Vault} from "../src/V4Vault.sol";
+// import {InterestRateModel} from "../src/InterestRateModel.sol";
+// import {FlashloanLiquidator} from "../src/utils/FlashloanLiquidator.sol";
+// import {LeverageTransformer} from "../src/transformers/LeverageTransformer.sol";
+import {LiquidityCalculator, ILiquidityCalculator} from "../src/LiquidityCalculator.sol";
+import {RevertHook} from "../src/RevertHook.sol";
+import {RevertHookFunctions} from "../src/RevertHookFunctions.sol";
+import {RevertHookFunctions2} from "../src/RevertHookFunctions2.sol";
+
+import {IPositionManager} from "@uniswap/v4-periphery/src/interfaces/IPositionManager.sol";
+import {IPermit2} from "@uniswap/v4-periphery/lib/permit2/src/interfaces/IPermit2.sol";
+// import {IWETH9} from "@uniswap/v4-periphery/src/interfaces/external/IWETH9.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+
+/// @title DeployUnichain
+/// @notice Deployment script for RevertHook and all related contracts on Unichain
+/// @dev Run with: forge script script/DeployUnichain.s.sol:DeployUnichain --chain-id 130 --rpc-url <rpc> --broadcast --verify
+contract DeployUnichain is Script {
+    uint256 constant Q32 = 2 ** 32;
+    uint256 constant Q64 = 2 ** 64;
+
+    // ==================== Unichain Contract Addresses ====================
+    // Source: https://docs.uniswap.org/contracts/v4/deployments
+
+    IPositionManager constant POSITION_MANAGER = IPositionManager(0x4529A01c7A0410167c5740C487A8DE60232617bf);
+    address constant UNIVERSAL_ROUTER = 0xEf740bf23aCaE26f6492B10de645D6B98dC8Eaf3;
+    address constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
+
+    // CREATE2 Deployer Proxy used by Forge for CREATE2 deployments
+    address constant CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+    // 0x Protocol AllowanceHolder - placeholder, update when available on Unichain
+    address constant ZEROX_ALLOWANCE_HOLDER = address(0); // TODO: Update when 0x deploys to Unichain
+
+    // ==================== Unichain Token Addresses ====================
+    // Common token addresses on Unichain mainnet
+
+    address constant WETH = 0x4200000000000000000000000000000000000006; // Standard OP Stack WETH
+    address constant ETH = address(0);
+
+    // Stablecoins - placeholder addresses, update with actual Unichain addresses
+    address constant USDC = 0x078D782b760474a361dDA0AF3839290b0EF57AD6;
+    address constant USDT = 0x9151434b16b9763660705744891fA906F660EcC5;
+    address constant DAI = 0x20CAb320A855b39F724131C69424240519573f81;
+
+    // Other tokens
+    address constant WBTC = 0x0555E30da8f98308EdB960aa94C0Db47230d2B9c;
+    address constant UNI = 0x8f187aA05619a017077f5308904739877ce9eA21;
+
+    // ==================== RedStone Oracle Feed Addresses ====================
+    // Source: https://docs.redstone.finance - Classic/Push Model feeds on Unichain
+    // These implement the Chainlink AggregatorV3Interface
+
+    address constant REDSTONE_ETH_USD = 0xe8D9FbC10e00ecc9f0694617075fDAF657a76FB2;
+    address constant REDSTONE_BTC_USD = 0xc44be6D00307c3565FDf753e852Fc003036cBc13;
+    address constant REDSTONE_USDC_USD = 0xD15862FC3D5407A03B696548b6902D6464A69b8c;
+    address constant REDSTONE_USDT_USD = 0x58fa68A373956285dDfb340EDf755246f8DfCA16;
+    address constant REDSTONE_DAI_USD = 0xE94c9f9A1893f23be38A5C0394E46Ac05e8a5f8C;
+    address constant REDSTONE_UNI_USD = 0xf1454949C6dEdfb500ae63Aa6c784Aa1Dde08A6c;
+
+    // L2 Sequencer Uptime Feed (for L2 oracle safety)
+    address constant SEQUENCER_UPTIME_FEED = address(0); // TODO: Update if RedStone provides sequencer feed
+
+    // ==================== Configuration Constants ====================
+
+    uint32 constant MAX_FEED_AGE = 86400; // 24 hours max feed age
+    uint16 constant MAX_POOL_PRICE_DIFFERENCE = 200; // 2% max difference between pool and oracle price
+
+    // // Interest rate model parameters (similar to Compound V2)
+    // uint256 constant BASE_RATE_PER_YEAR = 0; // 0% base rate
+    // uint256 constant MULTIPLIER_PER_YEAR = Q64 * 5 / 100; // 5% at kink
+    // uint256 constant JUMP_MULTIPLIER_PER_YEAR = Q64 * 109 / 100; // 109% above kink
+    // uint256 constant KINK = Q64 * 80 / 100; // 80% utilization kink
+
+    // // Collateral factors (in Q32 format)
+    // uint32 constant CF_STABLECOIN = uint32(Q32 * 850 / 1000); // 85% for stablecoins
+    // uint32 constant CF_ETH = uint32(Q32 * 775 / 1000); // 77.5% for ETH
+    // uint32 constant CF_BTC = uint32(Q32 * 750 / 1000); // 75% for BTC
+    // uint32 constant CF_OTHER = uint32(Q32 * 650 / 1000); // 65% for other tokens
+
+    // RevertHook configuration
+    uint16 constant PROTOCOL_FEE_BPS = 100; // 1% protocol fee
+    int24 constant MAX_TICKS_FROM_ORACLE = 100; // Max tick deviation from oracle price
+    uint256 constant MIN_POSITION_VALUE_NATIVE = 0.01 ether; // Minimum position value
+
+    // Maximum iterations for hook address mining
+    uint256 constant MAX_LOOP = 500_000;
+
+    /// @notice RevertHook required flags based on getHookPermissions()
+    /// afterInitialize, beforeAddLiquidity, afterAddLiquidity, afterRemoveLiquidity, afterSwap,
+    /// afterAddLiquidityReturnDelta, afterRemoveLiquidityReturnDelta
+    function getHookFlags() internal pure returns (uint160) {
+        return uint160(
+            Hooks.AFTER_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.AFTER_ADD_LIQUIDITY_FLAG
+                | Hooks.AFTER_REMOVE_LIQUIDITY_FLAG | Hooks.AFTER_SWAP_FLAG
+                | Hooks.AFTER_ADD_LIQUIDITY_RETURNS_DELTA_FLAG | Hooks.AFTER_REMOVE_LIQUIDITY_RETURNS_DELTA_FLAG
+        );
+    }
+
+    /// @notice Find a salt that produces a hook address with the correct flags
+    /// @dev Uses CREATE2 address computation to mine for valid hook addresses
+    /// @param deployer The address that will deploy the hook (msg.sender in broadcast context)
+    /// @param creationCodeWithArgs The creation code with constructor args appended
+    function findHookSalt(address deployer, bytes memory creationCodeWithArgs) internal view returns (address hookAddress, bytes32 salt) {
+        uint160 flags = getHookFlags();
+        uint160 flagMask = Hooks.ALL_HOOK_MASK;
+        flags = flags & flagMask;
+
+        for (uint256 i; i < MAX_LOOP; i++) {
+            salt = bytes32(i);
+            hookAddress = computeCreate2Address(deployer, salt, creationCodeWithArgs);
+
+            if (uint160(hookAddress) & flagMask == flags && hookAddress.code.length == 0) {
+                return (hookAddress, salt);
+            }
+        }
+        revert("DeployUnichain: could not find valid hook salt");
+    }
+
+    /// @notice Compute CREATE2 address
+    /// @param deployer The address deploying the contract
+    /// @param salt The CREATE2 salt
+    /// @param creationCodeWithArgs The creation code with constructor args
+    function computeCreate2Address(address deployer, bytes32 salt, bytes memory creationCodeWithArgs)
+        internal
+        pure
+        returns (address)
+    {
+        return address(
+            uint160(
+                uint256(keccak256(abi.encodePacked(bytes1(0xFF), deployer, salt, keccak256(creationCodeWithArgs))))
+            )
+        );
+    }
+
+    function run() external {
+        // Get deployer address for protocol fee recipient
+        address deployer = msg.sender;
+
+        vm.startBroadcast();
+
+        console.log("Deploying RevertHook infrastructure on Unichain...");
+        console.log("Deployer:", deployer);
+
+        // ==================== Step 1: Deploy Core Infrastructure ====================
+
+        // // Deploy InterestRateModel
+        // InterestRateModel interestRateModel = new InterestRateModel(
+        //     BASE_RATE_PER_YEAR,
+        //     MULTIPLIER_PER_YEAR,
+        //     JUMP_MULTIPLIER_PER_YEAR,
+        //     KINK
+        // );
+        // console.log("InterestRateModel deployed at:", address(interestRateModel));
+
+        // Deploy LiquidityCalculator
+        LiquidityCalculator liquidityCalculator = new LiquidityCalculator();
+        console.log("LiquidityCalculator deployed at:", address(liquidityCalculator));
+
+        // ==================== Step 2: Deploy V4Oracle ====================
+
+        // Deploy V4Oracle with WETH as reference token and USD (address(0)) as chainlink reference
+        V4Oracle oracle = new V4Oracle(POSITION_MANAGER, WETH, address(0));
+        console.log("V4Oracle deployed at:", address(oracle));
+
+        // Configure oracle settings
+        oracle.setMaxPoolPriceDifference(MAX_POOL_PRICE_DIFFERENCE);
+        oracle.setSequencerUptimeFeed(SEQUENCER_UPTIME_FEED);
+
+        // Configure token feeds (RedStone feeds implement AggregatorV3Interface)
+        // ETH/USD
+        if (REDSTONE_ETH_USD != address(0)) {
+            oracle.setTokenConfig(WETH, AggregatorV3Interface(REDSTONE_ETH_USD), MAX_FEED_AGE);
+            oracle.setTokenConfig(ETH, AggregatorV3Interface(REDSTONE_ETH_USD), MAX_FEED_AGE);
+            console.log("Configured ETH/USD feed");
+        }
+
+        // BTC/USD
+        if (REDSTONE_BTC_USD != address(0) && WBTC != address(0)) {
+            oracle.setTokenConfig(WBTC, AggregatorV3Interface(REDSTONE_BTC_USD), MAX_FEED_AGE);
+            console.log("Configured BTC/USD feed");
+        }
+
+        // USDC/USD
+        if (REDSTONE_USDC_USD != address(0) && USDC != address(0)) {
+            oracle.setTokenConfig(USDC, AggregatorV3Interface(REDSTONE_USDC_USD), MAX_FEED_AGE);
+            console.log("Configured USDC/USD feed");
+        }
+
+        // USDT/USD
+        if (REDSTONE_USDT_USD != address(0) && USDT != address(0)) {
+            oracle.setTokenConfig(USDT, AggregatorV3Interface(REDSTONE_USDT_USD), MAX_FEED_AGE);
+            console.log("Configured USDT/USD feed");
+        }
+
+        // DAI/USD
+        if (REDSTONE_DAI_USD != address(0) && DAI != address(0)) {
+            oracle.setTokenConfig(DAI, AggregatorV3Interface(REDSTONE_DAI_USD), MAX_FEED_AGE);
+            console.log("Configured DAI/USD feed");
+        }
+
+        // UNI/USD
+        if (REDSTONE_UNI_USD != address(0) && UNI != address(0)) {
+            oracle.setTokenConfig(UNI, AggregatorV3Interface(REDSTONE_UNI_USD), MAX_FEED_AGE);
+            console.log("Configured UNI/USD feed");
+        }
+
+        // ==================== Step 3: Deploy RevertHookFunctions contracts ====================
+
+        // Deploy RevertHookFunctions separately to avoid initcode size limit
+        RevertHookFunctions hookFunctions = new RevertHookFunctions(
+            IPermit2(PERMIT2),
+            oracle,
+            ILiquidityCalculator(liquidityCalculator)
+        );
+        console.log("RevertHookFunctions deployed at:", address(hookFunctions));
+
+        // Deploy RevertHookFunctions2 separately to avoid initcode size limit
+        RevertHookFunctions2 hookFunctions2 = new RevertHookFunctions2(
+            IPermit2(PERMIT2),
+            oracle,
+            ILiquidityCalculator(liquidityCalculator)
+        );
+        console.log("RevertHookFunctions2 deployed at:", address(hookFunctions2));
+
+        // ==================== Step 4: Deploy RevertHook with CREATE2 ====================
+
+        // Prepare constructor arguments for RevertHook
+        // Constructor: (owner_, protocolFeeRecipient_, permit2, v4Oracle, liquidityCalculator, hookFunctions, hookFunctions2)
+        bytes memory constructorArgs = abi.encode(
+            deployer,
+            deployer,
+            IPermit2(PERMIT2),
+            oracle,
+            ILiquidityCalculator(liquidityCalculator),
+            hookFunctions,
+            hookFunctions2
+        );
+        bytes memory creationCodeWithArgs = abi.encodePacked(type(RevertHook).creationCode, constructorArgs);
+
+        // Mine for a valid hook address
+        // Note: Forge uses CREATE2_DEPLOYER (0x4e59b44847b379578588920cA78FbF26c0B4956C) for CREATE2 deployments
+        console.log("Mining for valid hook address...");
+        (address expectedHookAddress, bytes32 salt) = findHookSalt(CREATE2_DEPLOYER, creationCodeWithArgs);
+        console.log("Found valid hook address:", expectedHookAddress);
+        console.log("Using salt:", vm.toString(salt));
+
+        // Deploy RevertHook using CREATE2
+        RevertHook revertHook = new RevertHook{salt: salt}(
+            deployer, // owner
+            deployer, // protocolFeeRecipient
+            IPermit2(PERMIT2),
+            oracle,
+            ILiquidityCalculator(liquidityCalculator),
+            hookFunctions,
+            hookFunctions2
+        );
+        require(address(revertHook) == expectedHookAddress, "Hook address mismatch");
+        console.log("RevertHook deployed at:", address(revertHook));
+
+        // Configure RevertHook settings
+        revertHook.setProtocolFeeBps(PROTOCOL_FEE_BPS);
+        revertHook.setMaxTicksFromOracle(MAX_TICKS_FROM_ORACLE);
+        revertHook.setMinPositionValueNative(MIN_POSITION_VALUE_NATIVE);
+
+        // // ==================== Step 4: Deploy V4Vault (USDC lending) ====================
+
+        // V4Vault vault;
+        // if (USDC != address(0)) {
+        //     vault = new V4Vault(
+        //         "Revert Lend USDC",
+        //         "rlUSDC",
+        //         USDC,
+        //         POSITION_MANAGER,
+        //         interestRateModel,
+        //         oracle,
+        //         IWETH9(WETH)
+        //     );
+        //     console.log("V4Vault (USDC) deployed at:", address(vault));
+
+        //     // Configure collateral tokens
+        //     if (USDC != address(0)) {
+        //         vault.setTokenConfig(USDC, CF_STABLECOIN, type(uint32).max);
+        //     }
+        //     vault.setTokenConfig(WETH, CF_ETH, type(uint32).max);
+        //     vault.setTokenConfig(ETH, CF_ETH, type(uint32).max);
+        //     if (WBTC != address(0)) {
+        //         vault.setTokenConfig(WBTC, CF_BTC, type(uint32).max);
+        //     }
+        //     if (USDT != address(0)) {
+        //         vault.setTokenConfig(USDT, CF_STABLECOIN, type(uint32).max);
+        //     }
+        //     if (DAI != address(0)) {
+        //         vault.setTokenConfig(DAI, CF_STABLECOIN, type(uint32).max);
+        //     }
+        //     if (UNI != address(0)) {
+        //         vault.setTokenConfig(UNI, CF_OTHER, type(uint32).max);
+        //     }
+
+        //     // Configure vault limits
+        //     vault.setLimits(
+        //         100000,           // minLoanSize: 0.1 USDC (assuming 6 decimals)
+        //         1000000000000,    // globalLendLimit: 1M USDC
+        //         399000000000000,  // globalDebtLimit
+        //         100000000000,     // dailyLendIncreaseLimitMin
+        //         75000000000       // dailyDebtIncreaseLimitMin
+        //     );
+        //     vault.setReserveFactor(uint32(Q32 * 10 / 100)); // 10% reserve factor
+        //     vault.setReserveProtectionFactor(uint32(Q32 * 5 / 100)); // 5% reserve protection
+
+        //     // Set up auto-lend vault in RevertHook
+        //     if (USDC != address(0)) {
+        //         revertHook.setAutoLendVault(USDC, vault);
+        //     }
+        // }
+
+        // // ==================== Step 5: Deploy Transformers ====================
+
+        // // Deploy FlashloanLiquidator
+        // FlashloanLiquidator flashloanLiquidator = new FlashloanLiquidator(
+        //     POSITION_MANAGER,
+        //     UNIVERSAL_ROUTER,
+        //     ZEROX_ALLOWANCE_HOLDER
+        // );
+        // console.log("FlashloanLiquidator deployed at:", address(flashloanLiquidator));
+
+        // // Deploy V4Utils
+        // V4Utils v4Utils = new V4Utils(
+        //     POSITION_MANAGER,
+        //     UNIVERSAL_ROUTER,
+        //     ZEROX_ALLOWANCE_HOLDER,
+        //     IPermit2(PERMIT2)
+        // );
+        // console.log("V4Utils deployed at:", address(v4Utils));
+
+        // // Deploy LeverageTransformer
+        // LeverageTransformer leverageTransformer = new LeverageTransformer(
+        //     POSITION_MANAGER,
+        //     UNIVERSAL_ROUTER,
+        //     ZEROX_ALLOWANCE_HOLDER,
+        //     IPermit2(PERMIT2)
+        // );
+        // console.log("LeverageTransformer deployed at:", address(leverageTransformer));
+
+        // // ==================== Step 6: Configure Vault-Transformer Integration ====================
+
+        // if (address(vault) != address(0)) {
+        //     v4Utils.setVault(address(vault));
+        //     vault.setTransformer(address(v4Utils), true);
+        //     console.log("V4Utils registered with vault");
+
+        //     leverageTransformer.setVault(address(vault));
+        //     vault.setTransformer(address(leverageTransformer), true);
+        //     console.log("LeverageTransformer registered with vault");
+
+        //     // Allow RevertHook in vault
+        //     vault.setHookAllowList(address(revertHook), true);
+        //     console.log("RevertHook added to vault hook allowlist");
+        // }
+
+        vm.stopBroadcast();
+
+        // ==================== Deployment Summary ====================
+
+        console.log("\n========== DEPLOYMENT SUMMARY ==========");
+        console.log("Chain: Unichain (130)");
+        console.log("LiquidityCalculator:", address(liquidityCalculator));
+        console.log("V4Oracle:", address(oracle));
+        console.log("RevertHookFunctions:", address(hookFunctions));
+        console.log("RevertHookFunctions2:", address(hookFunctions2));
+        console.log("RevertHook:", address(revertHook));
+        console.log("=========================================\n");
+    }
+}

--- a/script/configure-position.sh
+++ b/script/configure-position.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Configure a position on RevertHook for Unichain
+# Usage: ./script/configure-position.sh
+
+set -e
+
+# ==================== Configuration ====================
+
+# Unichain RPC
+RPC_URL="https://mainnet.unichain.org"
+
+# RevertHook contract address (update after deployment)
+REVERT_HOOK="0xfcafc56b43a0956ba8fe8d94f3a787cb53121d43"
+
+# Position to configure
+TOKEN_ID="2461350"
+
+# ==================== Position Configuration ====================
+# PositionConfig struct:
+#   PositionMode mode;              // enum: 0=NONE, 1=AUTO_COMPOUND_ONLY, 2=AUTO_RANGE, 3=AUTO_EXIT, 4=AUTO_EXIT_AND_AUTO_RANGE, 5=AUTO_LEND, 6=AUTO_LEVERAGE
+#   AutoCompoundMode autoCompoundMode; // enum: 0=NONE, 1=AUTO_COMPOUND, 2=HARVEST_TOKEN_0, 3=HARVEST_TOKEN_1
+#   bool autoExitIsRelative;        // if true, auto exit ticks are relative to position limits
+#   int24 autoExitTickLower;        // lower tick for auto-exit trigger
+#   int24 autoExitTickUpper;        // upper tick for auto-exit trigger
+#   int24 autoRangeLowerLimit;      // lower limit for auto-range
+#   int24 autoRangeUpperLimit;      // upper limit for auto-range
+#   int24 autoRangeLowerDelta;      // delta below current tick for new range
+#   int24 autoRangeUpperDelta;      // delta above current tick for new range
+#   int24 autoLendToleranceTick;    // tolerance for auto-lend
+#   uint16 autoLeverageTargetBps;   // target leverage ratio in bps (0-10000)
+
+# Example: AUTO_COMPOUND_ONLY mode
+MODE="1"                           # AUTO_COMPOUND_ONLY
+AUTO_COMPOUND_MODE="1"             # AUTO_COMPOUND
+AUTO_EXIT_IS_RELATIVE="false"
+AUTO_EXIT_TICK_LOWER="-8388608"    # type(int24).min - disabled
+AUTO_EXIT_TICK_UPPER="8388607"     # type(int24).max - disabled
+AUTO_RANGE_LOWER_LIMIT="-8388608"  # type(int24).min - disabled
+AUTO_RANGE_UPPER_LIMIT="8388607"   # type(int24).max - disabled
+AUTO_RANGE_LOWER_DELTA="0"
+AUTO_RANGE_UPPER_DELTA="0"
+AUTO_LEND_TOLERANCE_TICK="0"
+AUTO_LEVERAGE_TARGET_BPS="0"
+
+# ==================== General Configuration ====================
+# GeneralConfig for swap pool settings (optional, set to 0 to use same pool)
+SWAP_POOL_FEE="0"                  # 0 = use same pool
+SWAP_POOL_TICK_SPACING="0"         # 0 = use same pool
+SWAP_POOL_HOOKS="0x0000000000000000000000000000000000000000"
+MAX_PRICE_IMPACT_BPS_0="100"       # 1% max slippage for token0->token1 swaps
+MAX_PRICE_IMPACT_BPS_1="100"       # 1% max slippage for token1->token0 swaps
+
+# ==================== Helper Functions ====================
+
+print_header() {
+    echo ""
+    echo "=============================================="
+    echo "$1"
+    echo "=============================================="
+}
+
+# ==================== Main Script ====================
+
+print_header "RevertHook Position Configuration"
+
+echo "RPC URL: $RPC_URL"
+echo "RevertHook: $REVERT_HOOK"
+echo "Token ID: $TOKEN_ID"
+echo ""
+
+# Check if PRIVATE_KEY is set
+if [ -z "$PRIVATE_KEY" ]; then
+    echo "Error: PRIVATE_KEY environment variable not set"
+    echo "Usage: PRIVATE_KEY=0x... ./script/configure-position.sh"
+    exit 1
+fi
+
+print_header "Step 1: Set General Config (optional)"
+
+echo "Setting general config for token $TOKEN_ID..."
+echo "  Swap Pool Fee: $SWAP_POOL_FEE"
+echo "  Swap Pool Tick Spacing: $SWAP_POOL_TICK_SPACING"
+echo "  Max Price Impact (token0->token1): ${MAX_PRICE_IMPACT_BPS_0} bps"
+echo "  Max Price Impact (token1->token0): ${MAX_PRICE_IMPACT_BPS_1} bps"
+
+# setGeneralConfig(uint256 tokenId, uint24 swapPoolFee, int24 swapPoolTickSpacing, address swapPoolHooks, uint32 maxPriceImpactBps0, uint32 maxPriceImpactBps1)
+cast send "$REVERT_HOOK" \
+    "setGeneralConfig(uint256,uint24,int24,address,uint32,uint32)" \
+    "$TOKEN_ID" \
+    "$SWAP_POOL_FEE" \
+    "$SWAP_POOL_TICK_SPACING" \
+    "$SWAP_POOL_HOOKS" \
+    "$MAX_PRICE_IMPACT_BPS_0" \
+    "$MAX_PRICE_IMPACT_BPS_1" \
+    --rpc-url "$RPC_URL" \
+    --private-key "$PRIVATE_KEY"
+
+echo "General config set successfully!"
+
+print_header "Step 2: Set Position Config"
+
+echo "Setting position config for token $TOKEN_ID..."
+echo "  Mode: $MODE (1=AUTO_COMPOUND_ONLY)"
+echo "  Auto Compound Mode: $AUTO_COMPOUND_MODE (1=AUTO_COMPOUND)"
+
+# setPositionConfig(uint256 tokenId, (uint8,uint8,bool,int24,int24,int24,int24,int24,int24,int24,uint16) positionConfig)
+# The struct is passed as a tuple
+cast send "$REVERT_HOOK" \
+    "setPositionConfig(uint256,(uint8,uint8,bool,int24,int24,int24,int24,int24,int24,int24,uint16))" \
+    "$TOKEN_ID" \
+    "($MODE,$AUTO_COMPOUND_MODE,$AUTO_EXIT_IS_RELATIVE,$AUTO_EXIT_TICK_LOWER,$AUTO_EXIT_TICK_UPPER,$AUTO_RANGE_LOWER_LIMIT,$AUTO_RANGE_UPPER_LIMIT,$AUTO_RANGE_LOWER_DELTA,$AUTO_RANGE_UPPER_DELTA,$AUTO_LEND_TOLERANCE_TICK,$AUTO_LEVERAGE_TARGET_BPS)" \
+    --rpc-url "$RPC_URL" \
+    --private-key "$PRIVATE_KEY"
+
+echo "Position config set successfully!"
+
+print_header "Step 3: Verify Configuration"
+
+echo "Reading position config..."
+cast call "$REVERT_HOOK" \
+    "positionConfigs(uint256)" \
+    "$TOKEN_ID" \
+    --rpc-url "$RPC_URL"
+
+print_header "Configuration Complete!"
+
+echo "Position $TOKEN_ID is now configured for auto-compounding on RevertHook"
+echo ""

--- a/src/RevertHook.sol
+++ b/src/RevertHook.sol
@@ -51,19 +51,24 @@ contract RevertHook is RevertHookTriggers, BaseHook, IUnlockCallback {
     /// @notice The RevertHookFunctions2 contract for delegatecall (auto-leverage, auto-lend)
     RevertHookFunctions2 public immutable hookFunctions2;
 
-    constructor(address protocolFeeRecipient_, IPermit2 _permit2, V4Oracle _v4Oracle, ILiquidityCalculator _liquidityCalculator)
-        BaseHook(_v4Oracle.poolManager())
-        Ownable(msg.sender)
-    {
+    constructor(
+        address owner_,
+        address protocolFeeRecipient_,
+        IPermit2 _permit2,
+        V4Oracle _v4Oracle,
+        ILiquidityCalculator _liquidityCalculator,
+        RevertHookFunctions _hookFunctions,
+        RevertHookFunctions2 _hookFunctions2
+    ) BaseHook(_v4Oracle.poolManager()) Ownable(owner_) {
         positionManager = _v4Oracle.positionManager();
         protocolFeeRecipient = protocolFeeRecipient_;
         permit2 = _permit2;
         v4Oracle = _v4Oracle;
         liquidityCalculator = _liquidityCalculator;
 
-        // Deploy the functions contracts with the same immutable parameters
-        hookFunctions = new RevertHookFunctions(_permit2, _v4Oracle, _liquidityCalculator);
-        hookFunctions2 = new RevertHookFunctions2(_permit2, _v4Oracle, _liquidityCalculator);
+        // Use pre-deployed function contracts
+        hookFunctions = _hookFunctions;
+        hookFunctions2 = _hookFunctions2;
     }
 
     // ==================== Configuration Setters ====================

--- a/test/integration/V4OracleTest.t.sol
+++ b/test/integration/V4OracleTest.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {console} from "forge-std/console.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {V4ForkTestBase} from "./V4ForkTestBase.sol";
 import {V4Oracle, AggregatorV3Interface} from "../../src/V4Oracle.sol";
@@ -288,6 +289,190 @@ contract V4OracleTest is V4ForkTestBase {
             differenceBpsX100 <= maxDifferenceBpsX100 || maxDifferenceBpsX100 == type(uint16).max,
             "Price difference should be within maxPoolPriceDifference"
         );
+    }
+
+    /// @notice Test that getPoolSqrtPriceX96 is calculated correctly from Chainlink feeds
+    /// @dev Manually calculates the expected sqrtPriceX96 and compares to oracle result
+    function testGetPoolSqrtPriceX96Calculation() public {
+        console.log("=== Testing getPoolSqrtPriceX96 Calculation ===");
+
+        // Test pairs: (token0, token1)
+        // 1. WETH/USDC
+        _testSqrtPriceCalculation(WETH_ADDRESS, USDC_ADDRESS, "WETH/USDC");
+
+        // 2. USDC/WETH (reversed)
+        _testSqrtPriceCalculation(USDC_ADDRESS, WETH_ADDRESS, "USDC/WETH");
+
+        // 3. WBTC/USDC
+        _testSqrtPriceCalculation(WBTC_ADDRESS, USDC_ADDRESS, "WBTC/USDC");
+
+        // 4. DAI/USDC (stablecoin pair)
+        _testSqrtPriceCalculation(DAI_ADDRESS, USDC_ADDRESS, "DAI/USDC");
+
+        // 5. Native ETH/USDC
+        _testSqrtPriceCalculation(address(0), USDC_ADDRESS, "ETH/USDC");
+
+        // 6. Same token (edge case - should return Q96)
+        _testSqrtPriceCalculation(USDC_ADDRESS, USDC_ADDRESS, "USDC/USDC");
+
+        console.log("=== All getPoolSqrtPriceX96 Calculation Tests Passed ===");
+    }
+
+    /// @notice Helper to test sqrtPriceX96 calculation for a specific token pair
+    /// @param token0 First token address
+    /// @param token1 Second token address
+    /// @param pairName Name of the pair for logging
+    function _testSqrtPriceCalculation(address token0, address token1, string memory pairName) internal view {
+        console.log("");
+        console.log("--- Testing pair:", pairName, "---");
+
+        // Get oracle's sqrtPriceX96
+        uint160 oracleSqrtPriceX96 = v4Oracle.getPoolSqrtPriceX96(token0, token1);
+        console.log("Oracle sqrtPriceX96:", oracleSqrtPriceX96);
+
+        // Edge case: same token should return Q96
+        if (token0 == token1) {
+            assertEq(oracleSqrtPriceX96, uint160(Q96), "Same token should return Q96");
+            console.log("Verified: same token returns Q96");
+            return;
+        }
+
+        // Manually calculate expected sqrtPriceX96
+        // Formula: sqrt(price0X96 * Q96 / price1X96) * 2^48
+
+        // Get individual prices from Chainlink (in reference token terms)
+        uint256 price0X96 = _getManualPriceX96(token0);
+        uint256 price1X96 = _getManualPriceX96(token1);
+
+        console.log("Manual price0X96:", price0X96);
+        console.log("Manual price1X96:", price1X96);
+
+        // Calculate expected sqrtPriceX96
+        uint256 priceRatioX96 = price0X96 * Q96 / price1X96;
+        uint256 expectedSqrtPriceX96 = Math.sqrt(priceRatioX96) * (2 ** 48);
+
+        console.log("Expected sqrtPriceX96:", expectedSqrtPriceX96);
+
+        // Verify they match exactly
+        assertEq(oracleSqrtPriceX96, uint160(expectedSqrtPriceX96),
+            string(abi.encodePacked("sqrtPriceX96 mismatch for ", pairName)));
+
+        // Verify the price is reasonable (non-zero)
+        assertTrue(oracleSqrtPriceX96 > 0, "sqrtPriceX96 should be positive");
+
+        // Verify the actual price derived from sqrtPriceX96
+        // price = (sqrtPriceX96 / Q96)^2 = sqrtPriceX96^2 / Q96
+        uint256 derivedPriceX96 = (uint256(oracleSqrtPriceX96) * uint256(oracleSqrtPriceX96)) / Q96;
+        console.log("Derived priceX96 (token0/token1):", derivedPriceX96);
+
+        // The derived price should equal price0X96/price1X96
+        uint256 expectedPriceX96 = price0X96 * Q96 / price1X96;
+
+        // Allow small rounding error (< 0.01% due to sqrt precision)
+        uint256 priceDiff;
+        if (derivedPriceX96 >= expectedPriceX96) {
+            priceDiff = derivedPriceX96 - expectedPriceX96;
+        } else {
+            priceDiff = expectedPriceX96 - derivedPriceX96;
+        }
+
+        uint256 maxAllowedDiff = expectedPriceX96 / 10000; // 0.01%
+        assertTrue(priceDiff <= maxAllowedDiff,
+            "Derived price should match expected within 0.01%");
+
+        console.log("Verified:", pairName, "calculation is correct");
+    }
+
+    /// @notice Manually get priceX96 for a token using the same logic as V4Oracle
+    /// @dev Replicates _getReferenceTokenPriceX96 logic for verification
+    /// @param token Token address to get price for
+    /// @return priceX96 Price in Q96 format relative to reference token
+    function _getManualPriceX96(address token) internal view returns (uint256 priceX96) {
+        address referenceToken = v4Oracle.referenceToken();
+
+        // If token is the reference token, price is Q96
+        if (token == referenceToken) {
+            return Q96;
+        }
+
+        // Get Chainlink price for the token
+        uint256 chainlinkPriceX96 = _getManualChainlinkPriceX96(token);
+
+        // Get Chainlink price for reference token
+        uint256 chainlinkReferencePriceX96 = _getManualChainlinkPriceX96(referenceToken);
+
+        // Get token decimals
+        (,,,uint8 tokenDecimals) = v4Oracle.feedConfigs(token);
+        uint8 referenceTokenDecimals = v4Oracle.referenceTokenDecimals();
+
+        // Calculate price with decimal adjustment (same as V4Oracle._getReferenceTokenPriceX96)
+        if (referenceTokenDecimals > tokenDecimals) {
+            priceX96 = (10 ** (referenceTokenDecimals - tokenDecimals)) * chainlinkPriceX96
+                * Q96 / chainlinkReferencePriceX96;
+        } else if (referenceTokenDecimals < tokenDecimals) {
+            priceX96 = chainlinkPriceX96 * Q96 / chainlinkReferencePriceX96
+                / (10 ** (tokenDecimals - referenceTokenDecimals));
+        } else {
+            priceX96 = chainlinkPriceX96 * Q96 / chainlinkReferencePriceX96;
+        }
+    }
+
+    /// @notice Manually get Chainlink price in X96 format
+    /// @param token Token address
+    /// @return Chainlink price in Q96 format
+    function _getManualChainlinkPriceX96(address token) internal view returns (uint256) {
+        address chainlinkReferenceToken = v4Oracle.chainlinkReferenceToken();
+
+        // If token is the chainlink reference token (e.g., 0xdead for USD), return Q96
+        if (token == chainlinkReferenceToken) {
+            return Q96;
+        }
+
+        // Get feed config
+        (AggregatorV3Interface feed,, uint8 feedDecimals,) = v4Oracle.feedConfigs(token);
+
+        // Get latest price from Chainlink
+        (, int256 answer,,,) = feed.latestRoundData();
+
+        // Convert to Q96 format
+        return uint256(answer) * Q96 / (10 ** feedDecimals);
+    }
+
+    /// @notice Test sqrtPriceX96 symmetry - swapping token order should give inverse
+    function testGetPoolSqrtPriceX96Symmetry() public {
+        console.log("=== Testing getPoolSqrtPriceX96 Symmetry ===");
+
+        // Get sqrtPriceX96 for WETH/USDC
+        uint160 sqrtPrice_WETH_USDC = v4Oracle.getPoolSqrtPriceX96(WETH_ADDRESS, USDC_ADDRESS);
+
+        // Get sqrtPriceX96 for USDC/WETH (reversed)
+        uint160 sqrtPrice_USDC_WETH = v4Oracle.getPoolSqrtPriceX96(USDC_ADDRESS, WETH_ADDRESS);
+
+        console.log("sqrtPrice(WETH/USDC):", sqrtPrice_WETH_USDC);
+        console.log("sqrtPrice(USDC/WETH):", sqrtPrice_USDC_WETH);
+
+        // Calculate prices from sqrtPrices
+        uint256 price_WETH_USDC = (uint256(sqrtPrice_WETH_USDC) * uint256(sqrtPrice_WETH_USDC)) / Q96;
+        uint256 price_USDC_WETH = (uint256(sqrtPrice_USDC_WETH) * uint256(sqrtPrice_USDC_WETH)) / Q96;
+
+        console.log("price(WETH/USDC):", price_WETH_USDC);
+        console.log("price(USDC/WETH):", price_USDC_WETH);
+
+        // Verify: price_WETH_USDC * price_USDC_WETH should approximately equal Q96^2 / Q96 = Q96
+        // Because if WETH/USDC = X, then USDC/WETH = 1/X
+        // So X * (1/X) = 1, and in Q96 terms: priceX96 * inversePriceX96 / Q96 = Q96
+        uint256 product = (price_WETH_USDC * price_USDC_WETH) / Q96;
+
+        console.log("Product (should be ~Q96):", product);
+        console.log("Q96:", Q96);
+
+        // Allow 1% tolerance for rounding
+        uint256 tolerance = Q96 / 100;
+        uint256 diff = product > Q96 ? product - Q96 : Q96 - product;
+
+        assertTrue(diff < tolerance, "Price * inverse price should equal Q96 (within 1%)");
+
+        console.log("=== Symmetry Test Passed ===");
     }
 
     // recieves ETH from decreasing liquidity


### PR DESCRIPTION
- Add DeployUnichain.s.sol: Deployment script for RevertHook on Unichain (chain ID 130) with CREATE2 salt mining for valid hook addresses, RedStone oracle feeds for BTC, ETH, DAI, USDT, USDC, UNI
- Add configure-position.sh: Cast script for configuring positions on deployed RevertHook
- Update RevertHook constructor: Accept owner and pre-deployed RevertHookFunctions/RevertHookFunctions2 contracts to avoid initcode size limit
- Add V4Oracle tests: testGetPoolSqrtPriceX96Calculation verifies oracle price formula, testGetPoolSqrtPriceX96Symmetry verifies price inverse relationship

🤖 Generated with [Claude Code](https://claude.com/claude-code)