### PR TITLE
Refactor: Use IV4Oracle interface instead of concrete V4Oracle

### DIFF
--- a/src/RevertHook.sol
+++ b/src/RevertHook.sol
@@ -25,7 +25,7 @@ import {IPermit2} from "@uniswap/v4-periphery/lib/permit2/src/interfaces/IPermit
 
 import {ILiquidityCalculator} from "./LiquidityCalculator.sol";
 import {IVault} from "./interfaces/IVault.sol";
-import {V4Oracle} from "./V4Oracle.sol";
+import {IV4Oracle} from "./interfaces/IV4Oracle.sol";
 import {TickLinkedList} from "./lib/TickLinkedList.sol";
 import {RevertHookTriggers} from "./RevertHookTriggers.sol";
 import {RevertHookFunctions} from "./RevertHookFunctions.sol";
@@ -42,7 +42,7 @@ contract RevertHook is RevertHookTriggers, BaseHook, IUnlockCallback {
     IPermit2 public immutable permit2;
 
     IPositionManager public immutable positionManager;
-    V4Oracle public immutable v4Oracle;
+    IV4Oracle public immutable v4Oracle;
     ILiquidityCalculator public immutable liquidityCalculator;
 
     /// @notice The RevertHookFunctions contract for delegatecall (auto-exit, auto-range, auto-compound)
@@ -55,7 +55,7 @@ contract RevertHook is RevertHookTriggers, BaseHook, IUnlockCallback {
         address owner_,
         address protocolFeeRecipient_,
         IPermit2 _permit2,
-        V4Oracle _v4Oracle,
+        IV4Oracle _v4Oracle,
         ILiquidityCalculator _liquidityCalculator,
         RevertHookFunctions _hookFunctions,
         RevertHookFunctions2 _hookFunctions2

--- a/src/RevertHookFunctions.sol
+++ b/src/RevertHookFunctions.sol
@@ -10,7 +10,7 @@ import {IPermit2} from "@uniswap/v4-periphery/lib/permit2/src/interfaces/IPermit
 
 import {ILiquidityCalculator} from "./LiquidityCalculator.sol";
 import {IVault} from "./interfaces/IVault.sol";
-import {V4Oracle} from "./V4Oracle.sol";
+import {IV4Oracle} from "./interfaces/IV4Oracle.sol";
 import {RevertHookFunctionsBase} from "./RevertHookFunctionsBase.sol";
 
 /// @title RevertHookFunctions
@@ -20,7 +20,7 @@ contract RevertHookFunctions is RevertHookFunctionsBase {
 
     constructor(
         IPermit2 _permit2,
-        V4Oracle _v4Oracle,
+        IV4Oracle _v4Oracle,
         ILiquidityCalculator _liquidityCalculator
     ) RevertHookFunctionsBase(_permit2, _v4Oracle, _liquidityCalculator) {}
 

--- a/src/RevertHookFunctions2.sol
+++ b/src/RevertHookFunctions2.sol
@@ -13,7 +13,7 @@ import {IPermit2} from "@uniswap/v4-periphery/lib/permit2/src/interfaces/IPermit
 
 import {ILiquidityCalculator} from "./LiquidityCalculator.sol";
 import {IVault} from "./interfaces/IVault.sol";
-import {V4Oracle} from "./V4Oracle.sol";
+import {IV4Oracle} from "./interfaces/IV4Oracle.sol";
 import {RevertHookFunctionsBase} from "./RevertHookFunctionsBase.sol";
 
 /// @title RevertHookFunctions2
@@ -23,7 +23,7 @@ contract RevertHookFunctions2 is RevertHookFunctionsBase {
 
     constructor(
         IPermit2 _permit2,
-        V4Oracle _v4Oracle,
+        IV4Oracle _v4Oracle,
         ILiquidityCalculator _liquidityCalculator
     ) RevertHookFunctionsBase(_permit2, _v4Oracle, _liquidityCalculator) {}
 

--- a/src/RevertHookFunctionsBase.sol
+++ b/src/RevertHookFunctionsBase.sol
@@ -22,7 +22,7 @@ import {IPermit2} from "@uniswap/v4-periphery/lib/permit2/src/interfaces/IPermit
 
 import {ILiquidityCalculator} from "./LiquidityCalculator.sol";
 import {IVault} from "./interfaces/IVault.sol";
-import {V4Oracle} from "./V4Oracle.sol";
+import {IV4Oracle} from "./interfaces/IV4Oracle.sol";
 import {RevertHookTriggers} from "./RevertHookTriggers.sol";
 
 /// @title RevertHookFunctionsBase
@@ -34,11 +34,11 @@ abstract contract RevertHookFunctionsBase is RevertHookTriggers {
 
     IPermit2 public immutable permit2;
     IPositionManager public immutable positionManager;
-    V4Oracle public immutable v4Oracle;
+    IV4Oracle public immutable v4Oracle;
     ILiquidityCalculator public immutable liquidityCalculator;
     IPoolManager public immutable poolManager;
 
-    constructor(IPermit2 _permit2, V4Oracle _v4Oracle, ILiquidityCalculator _liquidityCalculator) Ownable(address(1)) {
+    constructor(IPermit2 _permit2, IV4Oracle _v4Oracle, ILiquidityCalculator _liquidityCalculator) Ownable(address(1)) {
         positionManager = _v4Oracle.positionManager();
         permit2 = _permit2;
         v4Oracle = _v4Oracle;

--- a/src/interfaces/IV4Oracle.sol
+++ b/src/interfaces/IV4Oracle.sol
@@ -2,9 +2,13 @@
 pragma solidity ^0.8.0;
 
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IPositionManager} from "@uniswap/v4-periphery/src/interfaces/IPositionManager.sol";
 
 // V4 Oracle Interface for position valuation
 interface IV4Oracle {
+    function poolManager() external view returns (IPoolManager);
+    function positionManager() external view returns (IPositionManager);
     function getPoolSqrtPriceX96(address token0, address token1) external view returns (uint160);
     function getValue(uint256 tokenId, address token) external view returns (uint256 value, uint256 feeValue, uint256 price0X96, uint256 price1X96);
     function getPositionBreakdown(uint256 tokenId) external view returns (Currency currency0, Currency currency1, uint24 fee, uint128 liquidity, uint256 amount0, uint256 amount1, uint128 fees0, uint128 fees1);

--- a/test/RevertHook.t.sol
+++ b/test/RevertHook.t.sol
@@ -24,7 +24,10 @@ import {EasyPosm} from "./utils/libraries/EasyPosm.sol";
 
 import {RevertHook} from "../src/RevertHook.sol";
 import {RevertHookState} from "../src/RevertHookState.sol";
+import {RevertHookFunctions} from "../src/RevertHookFunctions.sol";
+import {RevertHookFunctions2} from "../src/RevertHookFunctions2.sol";
 import {LiquidityCalculator, ILiquidityCalculator} from "../src/LiquidityCalculator.sol";
+import {IV4Oracle} from "../src/interfaces/IV4Oracle.sol";
 import {MockV4Oracle} from "./utils/MockV4Oracle.sol";
 import {BaseTest} from "./utils/BaseTest.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -93,7 +96,11 @@ contract RevertHookTest is BaseTest {
         // Deploy LiquidityCalculator
         liquidityCalculator = new LiquidityCalculator();
 
-        bytes memory constructorArgs = abi.encode(protocolFeeRecipient, permit2, v4Oracle, liquidityCalculator); // Add all the necessary constructor arguments from the hook
+        // Deploy RevertHookFunctions and RevertHookFunctions2
+        RevertHookFunctions hookFunctions = new RevertHookFunctions(permit2, v4Oracle, liquidityCalculator);
+        RevertHookFunctions2 hookFunctions2 = new RevertHookFunctions2(permit2, v4Oracle, liquidityCalculator);
+
+        bytes memory constructorArgs = abi.encode(address(this), protocolFeeRecipient, permit2, v4Oracle, liquidityCalculator, hookFunctions, hookFunctions2);
         deployCodeTo("RevertHook.sol:RevertHook", constructorArgs, flags);
         hook = RevertHook(flags);
 

--- a/test/integration/V4VaultHook.t.sol
+++ b/test/integration/V4VaultHook.t.sol
@@ -18,6 +18,8 @@ import {InterestRateModel} from "../../src/InterestRateModel.sol";
 
 import {RevertHook} from "../../src/RevertHook.sol";
 import {RevertHookState} from "../../src/RevertHookState.sol";
+import {RevertHookFunctions} from "../../src/RevertHookFunctions.sol";
+import {RevertHookFunctions2} from "../../src/RevertHookFunctions2.sol";
 import {LiquidityCalculator} from "../../src/LiquidityCalculator.sol";
 import {Constants} from "../../src/utils/Constants.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
@@ -73,7 +75,11 @@ contract V4VaultHookTest is V4ForkTestBase {
             ) ^ (0x4444 << 144) // Namespace the hook to avoid collisions
         );
 
-        bytes memory constructorArgs = abi.encode(address(this), permit2, v4Oracle, liquidityCalculator);
+        // Deploy RevertHookFunctions and RevertHookFunctions2
+        RevertHookFunctions hookFunctions = new RevertHookFunctions(permit2, v4Oracle, liquidityCalculator);
+        RevertHookFunctions2 hookFunctions2 = new RevertHookFunctions2(permit2, v4Oracle, liquidityCalculator);
+
+        bytes memory constructorArgs = abi.encode(address(this), address(this), permit2, v4Oracle, liquidityCalculator, hookFunctions, hookFunctions2);
         deployCodeTo("RevertHook.sol:RevertHook", constructorArgs, hookFlags);
         revertHook = RevertHook(hookFlags);
 


### PR DESCRIPTION
Update RevertHook and related contracts to accept IV4Oracle interface instead of the concrete V4Oracle contract, enabling better testability with mock implementations.

- Add poolManager() and positionManager() to IV4Oracle interface
- Update RevertHookFunctionsBase, RevertHookFunctions, RevertHookFunctions2
- Fix test files to deploy RevertHookFunctions with correct constructor args

🤖 Generated with [Claude Code](https://claude.ai/claude-code)