### PR TITLE
Require explicit hook allowlist for all hooks including address(0)

### DIFF
--- a/src/V4Vault.sol
+++ b/src/V4Vault.sol
@@ -967,12 +967,9 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
     }
 
     /// @notice Sets or updates the allow list for a hook (onlyOwner)
-    /// @param hook Hook to configure
+    /// @param hook Hook to configure (address(0) for positions without hooks)
     /// @param isAllowed Whether the hook is allowed
     function setHookAllowList(address hook, bool isAllowed) external onlyOwner {
-        if (hook == address(0)) {
-            revert InvalidConfig();
-        }
         hookAllowList[hook] = isAllowed;
         emit SetHookAllowList(hook, isAllowed);
     }
@@ -1489,7 +1486,7 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
     function _checkHookAllowed(uint256 tokenId) internal view {
         (PoolKey memory poolKey,) = positionManager.getPoolAndPositionInfo(tokenId);
-        if (address(poolKey.hooks) != address(0) && !hookAllowList[address(poolKey.hooks)]) {
+        if (!hookAllowList[address(poolKey.hooks)]) {
             revert HookNotAllowed();
         }
     }

--- a/test/integration/V4Vault.t.sol
+++ b/test/integration/V4Vault.t.sol
@@ -71,6 +71,9 @@ contract V4VaultTest is V4ForkTestBase {
         // without reserve for now
         vault.setReserveFactor(0);
 
+        // allow positions without hooks (address(0))
+        vault.setHookAllowList(address(0), true);
+
         vault.setTransformer(address(v4Utils), true);
         v4Utils.setVault(address(vault));
     }

--- a/test/integration/V4VaultHook.t.sol
+++ b/test/integration/V4VaultHook.t.sol
@@ -64,6 +64,9 @@ contract V4VaultHookTest is V4ForkTestBase {
         // without reserve for now
         vault.setReserveFactor(0);
 
+        // allow positions without hooks (address(0))
+        vault.setHookAllowList(address(0), true);
+
         // Deploy LiquidityCalculator
         liquidityCalculator = new LiquidityCalculator();
 


### PR DESCRIPTION
## Summary
- Require all hooks (including `address(0)`) to be explicitly added to the `hookAllowList`
- Previously, positions with no hook (`address(0)`) were allowed by default
- Now vault owners must call `setHookAllowList(address(0), true)` to allow positions without hooks

## Test plan
- [x] Run `forge test --match-path test/integration/V4Vault.t.sol` - all 35 tests pass
- [x] Run `forge test --match-path test/integration/V4VaultHook.t.sol` - all 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)