### PR TITLE
Add owner force-exit to standalone AutoLend (M-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Relevant admin calls:
 - allowed position hooks,
 - allowed transformer contracts.
 
+Only positions whose hook is explicitly allowlisted can be deposited as collateral. Non-hooked positions require allowlisting `address(0)`; the production deployment scripts allowlist only the `RevertHook`, so plain (non-hooked) v4 positions are not accepted as collateral unless an admin additionally allowlists `address(0)`.
+
 Relevant admin calls:
 
 - `V4Vault.setTokenConfig(...)`

--- a/src/automators/AutoLend.sol
+++ b/src/automators/AutoLend.sol
@@ -27,6 +27,7 @@ contract AutoLend is Automator {
     event SetAutoLendVault(address indexed token, IERC4626 vault);
     event AutoLendDeposit(uint256 indexed tokenId, address token, uint256 amount, uint256 shares);
     event AutoLendWithdraw(uint256 indexed tokenId, uint256 newTokenId, address token, uint256 amount, uint256 shares);
+    event AutoLendForceExit(uint256 indexed tokenId, address token, uint256 amount, uint256 shares);
     event PositionConfigured(
         uint256 indexed tokenId,
         bool isActive,
@@ -306,6 +307,52 @@ contract AutoLend is Automator {
         _sendRemainingBalances(posOwner, poolKey.currency0, poolKey.currency1);
 
         emit AutoLendWithdraw(params.tokenId, newTokenId, state.lentToken, redeemedAmount, state.shares);
+    }
+
+    /// @notice Position owner force-exits an active lend: redeems all vault shares and sends proceeds to the owner.
+    /// @dev Escape hatch so funds are never dependent on operators or on price returning to the withdraw zone.
+    /// Charges the configured max protocol fee on generated vault yield only and deactivates the position config.
+    function forceExit(uint256 tokenId) external nonReentrant {
+        LendState memory state = lendStates[tokenId];
+        if (state.shares == 0) {
+            revert NotConfigured();
+        }
+
+        address posOwner = IERC721(address(positionManager)).ownerOf(tokenId);
+        if (posOwner != msg.sender) {
+            revert Unauthorized();
+        }
+
+        (PoolKey memory poolKey,) = positionManager.getPoolAndPositionInfo(tokenId);
+
+        // @custom:accepted-risk AUDIT-ACCEPTED-AUTOLEND-REDEEM-FLOOR
+        // Accepts current ERC4626 redeem value without a minimum-assets guard; the owner
+        // explicitly opts into exiting at the vault's current rate.
+        uint256 redeemedAmount = IERC4626(state.vault).redeem(state.shares, address(this), address(this));
+
+        uint256 protocolFee;
+        {
+            uint256 yieldAmount = redeemedAmount > state.amount ? redeemedAmount - state.amount : 0;
+            (redeemedAmount, protocolFee) =
+                _calculateProtocolFee(redeemedAmount, yieldAmount, positionConfigs[tokenId].maxRewardX64);
+        }
+
+        // If lent token is native ETH (stored as WETH in vault), unwrap the full redeemed amount so
+        // protocol fees and owner proceeds are both handled in native ETH.
+        if (state.lentToken == address(0)) {
+            weth.withdraw(redeemedAmount + protocolFee);
+        }
+
+        // Clear all position state before external sends
+        vaultPositionCount[state.vault]--;
+        delete lendStates[tokenId];
+        delete positionConfigs[tokenId];
+
+        _sendProtocolFee(Currency.wrap(state.lentToken), protocolFee);
+        _sendRemainingBalances(posOwner, poolKey.currency0, poolKey.currency1);
+
+        emit AutoLendForceExit(tokenId, state.lentToken, redeemedAmount, state.shares);
+        emit PositionConfigured(tokenId, false, 0, 0, 0, 0, 0);
     }
 
     function _requireNonVaultPosition(uint256 tokenId) internal view returns (address posOwner) {

--- a/src/hook/RevertHookSwapActions.sol
+++ b/src/hook/RevertHookSwapActions.sol
@@ -27,6 +27,12 @@ contract RevertHookSwapActions is RevertHookState {
         hookFeeController = _hookFeeController;
     }
 
+    /// @dev Hook-managed swaps execute in the same pool the position lives in, against whatever
+    /// liquidity is available there at execution time — by design, with no oracle-based amountOutMin
+    /// floor (unlike the standalone automators' _routerSwapWithSlippageCheck). Trigger processing is
+    /// already gated to a pool price within _maxTicksFromOracle of the oracle price, and position
+    /// owners can opt into tighter per-swap bounds via setSwapProtectionConfig; beyond that, the swap
+    /// is intended to complete with what the pool offers rather than fail the automation.
     function executeSwap(PoolKey memory poolKey, bool zeroForOne, uint256 amountIn, uint256 tokenId, Mode mode)
         external
         returns (BalanceDelta delta)
@@ -36,6 +42,10 @@ contract RevertHookSwapActions is RevertHookState {
 
         uint160 sqrtPriceLimitX96;
         if (priceMultiplier == 0) {
+            // @custom:accepted-risk AUDIT-ACCEPTED-HOOK-SWAP-NO-SLIPPAGE-FLOOR
+            // No configured multiplier means no price limit. This is as designed: the swap runs in
+            // the position's own pool with the liquidity available there, bounded by the oracle
+            // trigger window; a slippage floor is intentionally not enforced here.
             sqrtPriceLimitX96 = zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1;
         } else {
             (uint160 currentSqrtPriceX96,,,) = StateLibrary.getSlot0(poolManager, poolKey.toId());

--- a/src/vault/V4Vault.sol
+++ b/src/vault/V4Vault.sol
@@ -452,7 +452,8 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
     /// @dev The position NFT must be approved for this contract. The recipient becomes the loan owner.
     /// @param tokenId The token ID of the Uniswap V4 position NFT to use as collateral
     /// @param recipient Address to receive ownership of the position/loan in the vault
-    /// @custom:security The hook attached to the position must be in hookAllowList or be address(0)
+    /// @custom:security The hook attached to the position (address(0) for non-hooked positions) must be in
+    /// hookAllowList. Non-hooked positions are only accepted if address(0) has been explicitly allowlisted.
     function create(uint256 tokenId, address recipient) external override {
         if (recipient == address(0)) {
             revert InvalidConfig();

--- a/test/automators/AutoLend.t.sol
+++ b/test/automators/AutoLend.t.sol
@@ -655,6 +655,123 @@ contract AutoLendTest is AutomatorTestBase {
         assertFalse(isActiveOld, "old position config should be cleared");
     }
 
+    function test_ForceExitRedeemsSharesToOwner() public {
+        PoolKey memory poolKey = _createPool();
+        _createFullRangePosition(poolKey);
+        uint256 tokenId = _createNarrowPosition(poolKey);
+
+        _configureAndApprove(tokenId, _defaultConfig(0));
+
+        // Move below range and deposit (token0/USDC lent)
+        _swapExactInputSingle(poolKey, true, 10000e6, 0);
+        _deposit(operator, _depositParams(tokenId));
+
+        (, uint256 shares, uint256 principal,) = autoLend.lendStates(tokenId);
+        assertGt(shares, 0, "position should be lent");
+        assertEq(autoLend.vaultPositionCount(address(usdcLendVault)), 1, "vault should be referenced");
+
+        uint256 ownerUsdcBefore = usdc.balanceOf(WHALE_ACCOUNT);
+
+        vm.prank(WHALE_ACCOUNT);
+        autoLend.forceExit(tokenId);
+        _assertNoAutomatorDust(address(autoLend), "AutoLend");
+
+        (, uint256 sharesAfter,,) = autoLend.lendStates(tokenId);
+        assertEq(sharesAfter, 0, "lend state should be cleared");
+        assertEq(autoLend.vaultPositionCount(address(usdcLendVault)), 0, "vault reference should be released");
+        assertGe(usdc.balanceOf(WHALE_ACCOUNT) - ownerUsdcBefore, principal, "owner should receive lent principal");
+
+        (bool isActive,,,,,) = autoLend.positionConfigs(tokenId);
+        assertFalse(isActive, "config should be deactivated after force exit");
+    }
+
+    function test_RevertWhenNonOwnerForceExits() public {
+        PoolKey memory poolKey = _createPool();
+        _createFullRangePosition(poolKey);
+        uint256 tokenId = _createNarrowPosition(poolKey);
+
+        _configureAndApprove(tokenId, _defaultConfig(0));
+
+        _swapExactInputSingle(poolKey, true, 10000e6, 0);
+        _deposit(operator, _depositParams(tokenId));
+
+        vm.prank(makeAddr("random"));
+        vm.expectRevert(Constants.Unauthorized.selector);
+        autoLend.forceExit(tokenId);
+
+        vm.prank(operator);
+        vm.expectRevert(Constants.Unauthorized.selector);
+        autoLend.forceExit(tokenId);
+    }
+
+    function test_RevertWhenForceExitWithoutActiveLend() public {
+        PoolKey memory poolKey = _createPool();
+        uint256 tokenId = _createNarrowPosition(poolKey);
+
+        vm.prank(WHALE_ACCOUNT);
+        vm.expectRevert(Constants.NotConfigured.selector);
+        autoLend.forceExit(tokenId);
+    }
+
+    function test_ForceExitChargesProtocolFeeOnYield() public {
+        PoolKey memory poolKey = _createPool();
+        _createFullRangePosition(poolKey);
+        uint256 tokenId = _createNarrowPosition(poolKey);
+
+        uint64 maxReward = uint64(Q64 * 10 / 100);
+        _configureAndApprove(tokenId, _defaultConfig(maxReward));
+
+        _swapExactInputSingle(poolKey, true, 10000e6, 0);
+        _deposit(operator, _depositParams(tokenId));
+
+        (, uint256 shares, uint256 principal,) = autoLend.lendStates(tokenId);
+        assertGt(shares, 0, "position should be lent");
+
+        uint256 donatedYield = principal + 1;
+        vm.prank(WHALE_ACCOUNT);
+        usdc.transfer(address(usdcLendVault), donatedYield);
+        usdcLendVault.simulatePositiveYield(10000); // +100% assets/share
+
+        uint256 recipientUsdcBefore = usdc.balanceOf(protocolFeeRecipient);
+
+        vm.prank(WHALE_ACCOUNT);
+        autoLend.forceExit(tokenId);
+        _assertNoAutomatorDust(address(autoLend), "AutoLend");
+
+        assertGt(
+            usdc.balanceOf(protocolFeeRecipient),
+            recipientUsdcBefore,
+            "protocol fee should be charged from vault yield on force exit"
+        );
+    }
+
+    function test_ForceExitETHNativePosition() public {
+        PoolKey memory poolKey = _createEthPool();
+        _createFullRangePositionEth(poolKey);
+        uint256 tokenId = _createNarrowPositionEth(poolKey);
+
+        autoLend.setAutoLendVault(address(0), IERC4626(address(wethLendVault)));
+        _configureAndApprove(tokenId, _defaultConfig(0));
+
+        _swapExactInputSingleEth(poolKey, true, 1e16, 0);
+        _deposit(operator, _depositParams(tokenId));
+
+        (address lentToken, uint256 shares, uint256 principal,) = autoLend.lendStates(tokenId);
+        assertEq(lentToken, address(0), "expected native ETH lend side");
+        assertGt(shares, 0, "position should be lent");
+
+        uint256 ownerEthBefore = WHALE_ACCOUNT.balance;
+
+        vm.prank(WHALE_ACCOUNT);
+        autoLend.forceExit(tokenId);
+        _assertNoAutomatorDust(address(autoLend), "AutoLend");
+
+        (, uint256 sharesAfter,,) = autoLend.lendStates(tokenId);
+        assertEq(sharesAfter, 0, "lend state should be cleared");
+        assertEq(address(autoLend).balance, 0, "no native ETH should remain in contract");
+        assertGe(WHALE_ACCOUNT.balance - ownerEthBefore, principal, "owner should receive native ETH proceeds");
+    }
+
     function test_ProtocolFeesAreSentToRecipient() public {
         PoolKey memory poolKey = _createPool();
         _createFullRangePosition(poolKey);


### PR DESCRIPTION
## Summary

Fixes audit findings **M-1** and **M-2**.

### M-1: Owner force-exit for standalone AutoLend

The standalone `AutoLend` automator had no owner exit path — the only way out of a lent position was the operator-only `withdraw()`, which additionally requires price to be near range. If operators went offline or price never returned to the withdraw zone, the owner's capital was locked in the ERC4626 vault indefinitely.

This adds an owner-gated `forceExit(tokenId)` mirroring the hook-side `autoLendForceExit()`:

- Callable only by the current position NFT owner; no operator involvement and no tick condition.
- Redeems all `lendStates[tokenId].shares` from the ERC4626 vault at the current rate (existing `AUDIT-ACCEPTED-AUTOLEND-REDEEM-FLOOR` accepted risk — the owner explicitly opts into exiting).
- Charges the protocol fee on generated vault yield only, at the position's configured `maxRewardX64` (the rate the owner already agreed to, so force-exit can't dodge fees the operator path would charge).
- Unwraps WETH to native ETH for native positions, matching `withdraw()`.
- Clears all state before external sends (lend state, vault refcount, position config — mirroring the hook's `_disablePosition`) and emits `AutoLendForceExit` plus a deactivating `PositionConfigured` event for indexers.
- Sends the fee to the protocol recipient and sweeps remaining balances to the owner.

### M-2: Document hook-only collateral allowlist (docs only)

The `create()` comment claimed positions with `address(0)` hooks are always accepted, but `_checkHookAllowed` requires every hook address — including `address(0)` — to be explicitly allowlisted, and the production deploy scripts only allowlist the `RevertHook`. The hook-only default is intentional: the comment is corrected and the README now documents that accepting non-hooked positions requires an admin to allowlist `address(0)`.

### M-3: Document as-designed absence of hook swap slippage floor (docs only)

Hook-managed swaps (auto-exit, auto-range, auto-collect, auto-leverage) intentionally execute in the position's own pool against whatever liquidity is available there, with no oracle-based `amountOutMin` floor. Protection comes from the `_maxTicksFromOracle` trigger-processing window plus optional per-position sqrt-price multipliers (`setSwapProtectionConfig`). This design decision is now documented on `executeSwap` with an `AUDIT-ACCEPTED-HOOK-SWAP-NO-SLIPPAGE-FLOOR` accepted-risk marker.

## Testing

- 5 new tests for `forceExit`: owner redemption happy path, non-owner revert, no-active-lend revert, fee-on-yield, native ETH exit.
- Full suite passes: 535 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
