### PR TITLE
Fix and document low-severity audit findings (L-1 to L-6)

### DIFF
--- a/src/hook/RevertHookCallbacks.sol
+++ b/src/hook/RevertHookCallbacks.sol
@@ -161,6 +161,10 @@ abstract contract RevertHookCallbacks is RevertHookExecution {
         ModifyLiquidityParams calldata,
         bytes calldata
     ) internal view override returns (bytes4) {
+        // NOTE: in practice sender is always the PositionManager - the hook's own liquidity
+        // operations also go through positionManager.modifyLiquidities, so the address(this)
+        // alternative here (and the sender == address(this) early-returns below) are defensive
+        // and currently unreachable. Do not build new logic on those branches firing.
         if (sender != address(positionManager) && sender != address(this)) {
             revert Unauthorized();
         }
@@ -179,6 +183,8 @@ abstract contract RevertHookCallbacks is RevertHookExecution {
 
         feeDelta = _takeProtocolFees(tokenId, key, feeDelta);
 
+        // defensive: sender is always the PositionManager today (see _beforeAddLiquidity note);
+        // hook-internal operations run the logic below, which is idempotent by design
         if (sender == address(this)) {
             return (BaseHook.afterAddLiquidity.selector, feeDelta);
         }
@@ -204,6 +210,8 @@ abstract contract RevertHookCallbacks is RevertHookExecution {
         uint256 tokenId = uint256(params.salt);
         feeDelta = _takeProtocolFees(tokenId, key, feeDelta);
 
+        // defensive: sender is always the PositionManager today (see _beforeAddLiquidity note);
+        // hook-internal operations run the logic below, which is idempotent by design
         if (sender == address(this)) {
             return (BaseHook.afterRemoveLiquidity.selector, feeDelta);
         }

--- a/src/hook/lib/TickLinkedList.sol
+++ b/src/hook/lib/TickLinkedList.sol
@@ -198,6 +198,11 @@ library TickLinkedList {
 
     /**
      * @dev Pops up to maxCount tokenIds from a tick without copying the full tick array.
+     * Popped entries are not cleared - tokenIdStart just advances past them. Because add()
+     * only dedups against the active region [tokenIdStart, length), a popped tokenId that is
+     * re-inserted at the same tick (e.g. requeued after a partial pop) is appended again,
+     * temporarily duplicating it in the array. This is accepted: duplicates are bounded by
+     * the per-swap execution cap and the whole array is deleted once the tick fully drains.
      * @param self Stored linked list from contract.
      * @param _tick The tick value.
      * @param maxCount Maximum number of tokenIds to pop.

--- a/src/shared/NativeAssetLib.sol
+++ b/src/shared/NativeAssetLib.sol
@@ -19,6 +19,14 @@ library NativeAssetLib {
         return 0;
     }
 
+    /// @notice Returns the contract's whole native balance when one of the pool tokens is native, 0 otherwise.
+    /// @dev Used to attach msg.value to modifyLiquidities calls: whole-balance forwarding is only safe
+    /// when the action set includes a native SWEEP back to the caller; for non-native pools no value
+    /// must be attached, or stray ETH would be donated to the PoolManager.
+    function balanceIfNative(Currency token0, Currency token1) internal view returns (uint256) {
+        return (token0.isAddressZero() || token1.isAddressZero()) ? address(this).balance : 0;
+    }
+
     function isDirectWrappedNativeSwap(IWETH9 weth, Currency tokenIn, Currency tokenOut)
         internal
         pure

--- a/src/vault/V4Vault.sol
+++ b/src/vault/V4Vault.sol
@@ -52,6 +52,9 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
     uint32 public constant MIN_RESERVE_PROTECTION_FACTOR_X32 = uint32(Q32 / 100); //1%
 
     // forge-lint: disable-next-line(unsafe-typecast)
+    uint32 public constant MAX_RESERVE_FACTOR_X32 = uint32(Q32 / 2); //50%
+
+    // forge-lint: disable-next-line(unsafe-typecast)
     uint32 public constant MAX_DAILY_LEND_INCREASE_X32 = uint32(Q32 / 10); //10%
     // forge-lint: disable-next-line(unsafe-typecast)
     uint32 public constant MAX_DAILY_DEBT_INCREASE_X32 = uint32(Q32 / 10); //10%
@@ -472,6 +475,11 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
             revert Unauthorized();
         }
 
+        // the vault must actually hold the NFT - prevents registering a loan for a position not in custody
+        if (IERC721(address(positionManager)).ownerOf(tokenId) != address(this)) {
+            revert Unauthorized();
+        }
+
         _handleErc721Received(tokenId, recipient);
     }
 
@@ -548,6 +556,10 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
     }
 
     /// @notice Allows another address to call transform on behalf of owner (on a given token)
+    /// @dev Approvals are keyed per (owner, tokenId, target) and are NOT cleared by remove(): if the
+    /// same owner re-deposits the same tokenId later, previously granted approvals are active again.
+    /// Approvals are also copied to the replacement tokenId when a transform remints the position.
+    /// Owners who want to revoke access must call this with isActive = false per target.
     /// @param tokenId The token to be permitted
     /// @param target The address to be allowed
     /// @param isActive If it allowed or not
@@ -870,6 +882,9 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
     }
 
     /// @notice Removes position from the vault (only possible when all repayed)
+    /// @dev Transform approvals granted via approveTransform are intentionally not cleared here (the
+    /// per-target inner mapping cannot be enumerated); they become active again if the same owner
+    /// re-deposits the same tokenId. See approveTransform for revocation.
     /// @param tokenId The token ID to use as collateral
     /// @param recipient Address to recieve NFT
     /// @param data Optional data to send to reciever
@@ -974,6 +989,9 @@ contract V4Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
     /// @notice sets reserve factor - percentage difference between debt and lend interest (onlyOwner)
     /// @param _reserveFactorX32 reserve factor multiplied by Q32
     function setReserveFactor(uint32 _reserveFactorX32) external onlyOwner {
+        if (_reserveFactorX32 > MAX_RESERVE_FACTOR_X32) {
+            revert InvalidConfig();
+        }
         // update interest to be sure that reservefactor change is applied from now on
         _updateGlobalInterest();
         reserveFactorX32 = _reserveFactorX32;

--- a/src/vault/transformers/LeverageTransformer.sol
+++ b/src/vault/transformers/LeverageTransformer.sol
@@ -19,6 +19,7 @@ import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 
 import {Swapper} from "../../shared/swap/Swapper.sol";
+import {NativeAssetLib} from "../../shared/NativeAssetLib.sol";
 import {IVault} from "../interfaces/IVault.sol";
 import {Transformer} from "./Transformer.sol";
 
@@ -115,7 +116,7 @@ contract LeverageTransformer is Transformer, Swapper, IERC721Receiver {
             params.tokenId, liquidity, type(uint128).max, type(uint128).max, params.increaseLiquidityHookData
         );
 
-        positionManager.modifyLiquidities{value: address(this).balance}(
+        positionManager.modifyLiquidities{value: NativeAssetLib.balanceIfNative(token0, token1)}(
             abi.encode(actions, paramsArray), params.deadline
         );
 
@@ -483,7 +484,7 @@ contract LeverageTransformer is Transformer, Swapper, IERC721Receiver {
             params.mintHookData
         );
 
-        positionManager.modifyLiquidities{value: address(this).balance}(
+        positionManager.modifyLiquidities{value: NativeAssetLib.balanceIfNative(poolKey.currency0, poolKey.currency1)}(
             abi.encode(actions, mintParams), params.deadline
         );
     }
@@ -643,7 +644,7 @@ contract LeverageTransformer is Transformer, Swapper, IERC721Receiver {
             params.mintHookData
         );
 
-        positionManager.modifyLiquidities{value: address(this).balance}(
+        positionManager.modifyLiquidities{value: NativeAssetLib.balanceIfNative(params.token0, params.token1)}(
             abi.encode(actions, mintParams), params.deadline
         );
 

--- a/src/vault/transformers/V4Utils.sol
+++ b/src/vault/transformers/V4Utils.sol
@@ -17,6 +17,7 @@ import {PositionInfo} from "@uniswap/v4-periphery/src/libraries/PositionInfoLibr
 import {Actions} from "@uniswap/v4-periphery/src/libraries/Actions.sol";
 
 import {Swapper} from "../../shared/swap/Swapper.sol";
+import {NativeAssetLib} from "../../shared/NativeAssetLib.sol";
 import {Transformer} from "./Transformer.sol";
 
 /// @title V4Utils v1.0
@@ -773,7 +774,7 @@ contract V4Utils is Transformer, Swapper, IERC721Receiver {
             params.mintHookData // hookData
         );
 
-        positionManager.modifyLiquidities{value: address(this).balance}(
+        positionManager.modifyLiquidities{value: NativeAssetLib.balanceIfNative(params.token0, params.token1)}(
             abi.encode(actions, paramsArray), params.deadline
         );
 
@@ -802,7 +803,7 @@ contract V4Utils is Transformer, Swapper, IERC721Receiver {
 
         paramsArray[0] = abi.encode(params.tokenId, liquidity, total0, total1, params.increaseLiquidityHookData);
 
-        positionManager.modifyLiquidities{value: address(this).balance}(
+        positionManager.modifyLiquidities{value: NativeAssetLib.balanceIfNative(poolKey.currency0, poolKey.currency1)}(
             abi.encode(actions, paramsArray), params.deadline
         );
 

--- a/test/vault/V4Vault.t.sol
+++ b/test/vault/V4Vault.t.sol
@@ -2124,6 +2124,37 @@ contract V4VaultTest is V4ForkTestBase {
         vault.notifyERC721Received(nft1TokenId, nft1Owner);
     }
 
+    function test_NotifyERC721Received_RevertWithoutCustody() public {
+        _setupBasicLoan(false);
+
+        NotifyWithoutCustodyTransformer transformer = new NotifyWithoutCustodyTransformer(vault);
+        vault.setTransformer(address(transformer), true);
+
+        // nft2 exists but the vault does not hold it - a transformer must not be
+        // able to register it as a loan during transform
+        assertEq(
+            IERC721(address(positionManager)).ownerOf(nft2TokenId), nft2Owner, "vault should not hold nft2"
+        );
+
+        vm.prank(nft1Owner);
+        vm.expectRevert(Constants.TransformFailed.selector);
+        vault.transform(
+            nft1TokenId,
+            address(transformer),
+            abi.encodeCall(NotifyWithoutCustodyTransformer.attemptNotify, (nft2TokenId))
+        );
+    }
+
+    function test_SetReserveFactor_RevertAboveMax() public {
+        uint32 maxReserveFactor = vault.MAX_RESERVE_FACTOR_X32();
+
+        vault.setReserveFactor(maxReserveFactor);
+        assertEq(vault.reserveFactorX32(), maxReserveFactor, "max reserve factor should be accepted");
+
+        vm.expectRevert(Constants.InvalidConfig.selector);
+        vault.setReserveFactor(maxReserveFactor + 1);
+    }
+
     function test_DecreaseLiquidityAndCollect_AllowsHealthyWithdrawal() public {
         _setupBasicLoan(false);
 
@@ -2234,6 +2265,18 @@ contract DecreaseLiquidityDuringTransformTransformer {
 
     function attemptDecrease(IVault.DecreaseLiquidityAndCollectParams calldata params) external {
         vault.decreaseLiquidityAndCollect(params);
+    }
+}
+
+contract NotifyWithoutCustodyTransformer {
+    IVault internal immutable vault;
+
+    constructor(IVault _vault) {
+        vault = _vault;
+    }
+
+    function attemptNotify(uint256 foreignTokenId) external {
+        vault.notifyERC721Received(foreignTokenId, address(this));
     }
 }
 


### PR DESCRIPTION
## Summary

Addresses the six low-severity audit findings. Two are code fixes, one is a capped config, three are documentation of intentional/accepted behavior.

### L-1: `notifyERC721Received` custody check (fix)

A whitelisted transformer could, during an active transform, register an NFT the vault doesn't hold as a loan. The final custody/health checks in `transform()` fence off the end state, but the injection point itself was unguarded. `notifyERC721Received` now requires `ownerOf(tokenId) == address(vault)`, failing fast at the point of injection. The only shipped caller (hook remint flow) mints to the vault before notifying, so no legitimate path changes.

### L-2: `setReserveFactor` cap (fix)

Note: the audit's underflow/DoS claim doesn't hold — `reserveFactorX32` is a `uint32` and `Q32 = 2^32`, so `Q32 - reserveFactorX32` can never underflow. The residual issue is that a max value silently zeroes lender yield. `setReserveFactor` is now capped at 50% (`MAX_RESERVE_FACTOR_X32`).

### L-3: stale transform approvals (documented)

The suggested fix (clearing `transformApprovals[owner][tokenId]` in `remove()`) is not implementable — the per-target inner mapping cannot be enumerated in Solidity; a real fix would need an approval-epoch redesign. Documented on `approveTransform`/`remove`: approvals are per-tokenId, survive loan cycles, and are copied to reminted tokens; revocation is per target.

### L-4: dead `sender == address(this)` branches (documented)

Confirmed unreachable — the hook's own liquidity operations go through the PositionManager. Kept as defensive code and documented so future refactors don't build logic on those branches firing.

### L-5: TickLinkedList transient duplicates (documented)

Popped-then-requeued tokenIds are appended again because dedup only scans the active region. Accepted: bounded by the per-swap execution cap and self-healing when the tick drains. Documented on `popTokenIds`.

### L-6: stray native ETH forwarding (fix)

`V4Utils` and `LeverageTransformer` attached `address(this).balance` to every `modifyLiquidities` call. For native pools this is safe (the action set includes a `SWEEP` back), but for non-native pools stray ETH would be donated to the PoolManager where anyone can claim it. New `NativeAssetLib.balanceIfNative` attaches value only when a pool token is native (5 call sites). The vault-side ETH sweep suggested by the finding was intentionally skipped — all vault ETH flows end flat, and a sweep would add unnecessary owner surface.

## Testing

- New: transformer cannot register a non-custodied NFT during transform (`TransformFailed`); reserve factor accepts 50% and rejects 50%+1.
- Full suite passes: 537 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)